### PR TITLE
Added onAllComplete

### DIFF
--- a/client/fileuploader.js
+++ b/client/fileuploader.js
@@ -957,7 +957,7 @@ qq.UploadHandlerAbstract.prototype = {
     },
     _onAllComplete: function(){
       this._options.onAllComplete(this._completed_files);
-    },
+    }
 };
 
 /**


### PR DESCRIPTION
Hi there,
we started using your file-uploader a while back and noticed that the onComplete even is triggered for every file in a batch. We needed to reload the list of images from the server only when _all_ images in a batch had finished uploading so I added the onAllComplete event.

Might be useful to others.

(also some minor fixes in there, mainly accepting the "201 Created" http status, which is what a standard Rails #create action would return)

Thanks,
David
