### PR TITLE
Better allowedExtensions check

### DIFF
--- a/client/fileuploader.js
+++ b/client/fileuploader.js
@@ -447,13 +447,13 @@ qq.FileUploaderBasic.prototype = {
         return name;
     },
     _isAllowedExtension: function(fileName){
-        var ext = (-1 !== fileName.indexOf('.')) ? fileName.replace(/.*[.]/, '').toLowerCase() : '';
         var allowed = this._options.allowedExtensions;
+        var lcaseFn = fileName.toLowerCase();
         
         if (!allowed.length){return true;}        
         
         for (var i=0; i<allowed.length; i++){
-            if (allowed[i].toLowerCase() == ext){ return true;}    
+            if (allowed[i].toLowerCase() == lcaseFn.substr(-allowed[i].length)){ return true;}
         }
         
         return false;

--- a/client/fileuploader.js
+++ b/client/fileuploader.js
@@ -447,7 +447,7 @@ qq.FileUploaderBasic.prototype = {
         return name;
     },
     _isAllowedExtension: function(fileName){
-        var allowed = this._options.allowedExtensions;
+        var allowed = this._options.allowedExtensions.map(function(n){return '.' + n});
         var lcaseFn = fileName.toLowerCase();
         
         if (!allowed.length){return true;}        


### PR DESCRIPTION
the original one (get file extension, check if it's listed on allowedExtensions) does not work with multiple suffixes (like file.tar.gz), because its hard to tell what is "extension" there.

This one is better: if filename ends with something that is listed on allowedExtensions, it's ok.
