### PR TITLE
Firefox and Chrome filesize property

### DIFF
--- a/client/fileuploader.js
+++ b/client/fileuploader.js
@@ -404,6 +404,9 @@ qq.FileUploaderBasic.prototype = {
             // it is a file input            
             // get input value and remove path to normalize
             name = file.value.replace(/.*(\/|\\)/, "");
+			if(file.files) {
+				size = file.files[0].fileSize;
+			}
         } else {
             // fix missing properties in Safari
             name = file.fileName != null ? file.fileName : file.name;


### PR DESCRIPTION
Small change to get the size of the file to be uploaded, to "alert()" the error message in case it's over the limit.
It was needed for Iceweasel and Chromium (Debian versions of Firefox and Chrome)
