### PR TITLE
Identifying list items in callback

### DIFF
--- a/client/fileuploader.js
+++ b/client/fileuploader.js
@@ -624,6 +624,7 @@ qq.extend(qq.FileUploader.prototype, {
     _addToList: function(id, fileName){
         var item = qq.toElement(this._options.fileTemplate);                
         item.qqFileId = id;
+        item.dataset.uploader_id = id;
 
         var fileElement = this._find(item, 'file');        
         qq.setText(fileElement, this._formatFileName(fileName));


### PR DESCRIPTION
I found it useful to have an attribute that corresponded to the uploader id number, which could be used in callbacks – to find the list item that corresponded to the upload.
