### PR TITLE
Set content-type

### DIFF
--- a/client/fileuploader.js
+++ b/client/fileuploader.js
@@ -1200,7 +1200,7 @@ qq.extend(qq.UploadHandlerXhr.prototype, {
         xhr.open("POST", queryString, true);
         xhr.setRequestHeader("X-Requested-With", "XMLHttpRequest");
         xhr.setRequestHeader("X-File-Name", encodeURIComponent(name));
-        xhr.setRequestHeader("Content-Type", "application/octet-stream");
+        xhr.setRequestHeader("Content-Type", file.type);
         xhr.send(file);
     },
     _onComplete: function(id, xhr){


### PR DESCRIPTION
Set the upload's content-type to the browser's notion of the file's type, rather than always using "application/octet-stream"
