### PR TITLE
Fix Issue #254, allow to dispose() upload handler

### DIFF
--- a/tests/test-detach-handlers.htm
+++ b/tests/test-detach-handlers.htm
@@ -1,0 +1,66 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+  <script src="jquery-1.4.2.min.js" type="text/javascript"></script>
+
+  <link href="qunit/qunit/qunit.css" rel="stylesheet" type="text/css" media="screen" />
+	<script src="qunit/qunit/qunit.js" type="text/javascript"></script>
+	
+	<script src="../client/fileuploader.js" type="text/javascript" ></script>
+	<script>
+    var run_tests = function() {
+
+    test("detach call", function(){
+
+      var stopper = qq.attach($("#placeholder")[0], "click", function() {});
+
+      var log = "";
+      qq.detach = function(what, event, handler) {
+        log += what.id + "_" + event;
+      };
+
+      stopper();
+      equal(log, "placeholder_click", "Should call detach");
+    });
+
+    test("dispose generic", function(){
+
+      var attach_count = 0;
+      var detach_count = 0;
+
+      var attach = qq.attach;
+      var detach = qq.detach;
+      qq.attach = function() {
+        attach_count++;
+        return attach.apply(this, arguments);
+      };
+      qq.detach = function() {
+        detach_count++;
+        return detach.apply(this, arguments);
+      };
+
+      var uploader = new qq.FileUploader({
+        // pass the dom node (ex. $(selector)[0] for jQuery users)
+        element: $("#placeholder")[0]
+      });
+
+      uploader.dispose();
+
+      equal(detach_count, attach_count - 1, "Should remove all events, excluding event which disables drop outside");
+
+    });
+
+    }
+  </script>
+</head>
+<body onload="run_tests();">
+<h1 id="qunit-header">File uploader tests</h1>
+<h2 id="qunit-banner"></h2>
+<h2 id="qunit-userAgent"></h2>
+<ol id="qunit-tests"></ol>
+
+<div id="placeholder"></div>
+</body> 
+</html>
+
+


### PR DESCRIPTION
Add support for "dispose()" method, which removes all but one global associated event handler.
A test is provided as well.
