### PR TITLE
Support for continuing a paused upload.

### DIFF
--- a/client/fileuploader.js
+++ b/client/fileuploader.js
@@ -391,10 +391,15 @@ qq.FileUploaderBasic.prototype = {
     _uploadFile: function(fileContainer){      
         var id = this._handler.add(fileContainer);
         var fileName = this._handler.getName(id);
+
+        var self = this;
+        var cb = function (){
+            self._onSubmit(id, fileName);
+            self._handler.upload(id, self._options.params);
+        };
         
-        if (this._options.onSubmit(id, fileName) !== false){
-            this._onSubmit(id, fileName);
-            this._handler.upload(id, this._options.params);
+        if (this._options.onSubmit(id, fileName, cb) !== false){
+            cb();
         }
     },      
     _validateFile: function(file){


### PR DESCRIPTION
Returning false from onSubmit allows you to stop the upload. There is
currently no way to temporarily halt the upload and restart it later.

This commit adds a callback parameter to onSubmit, which can be used to
continue the upload later on.

We need this in the following situation:
- Imagine a document management application. The user is looking at
  the "new document" screen, which is just a single upload field.
- When the user clicks submit, we'll pause the upload by returning
  false from onSubmit.
- We then send another AJAX request to the backend, to create a new
  entity.
- Once that returns, we use the returned value to set the target of
  the uploader to the newly created ID and continue the uploader by
  invoking cb(). This then attaches the file to the entity.
