### PR TITLE
Correctly append protocol(/method) when building form tag. Fixes #292.

### DIFF
--- a/client/fileuploader.js
+++ b/client/fileuploader.js
@@ -1299,7 +1299,7 @@ qq.extend(qq.UploadHandlerForm.prototype, {
 		// form.setAttribute('enctype', 'multipart/form-data');
 		// Because in this case file won't be attached to request
         var protocol = this._options.demoMode ? "GET" : "POST"
-        var form = qq.toElement('<form method=protocol enctype="multipart/form-data"></form>');
+		var form = qq.toElement('<form method="' + protocol + '" enctype="multipart/form-data"></form>');
 
 		var queryString = qq.obj2url(params, this._options.action);
 


### PR DESCRIPTION
This resolves an issue that was preventing IE and Opera from uploading.
