### PR TITLE
clearStoredFiles fails if listElement===null

### DIFF
--- a/client/fileuploader.js
+++ b/client/fileuploader.js
@@ -347,7 +347,9 @@ qq.FileUploaderBasic.prototype = {
 	},
 	clearStoredFiles: function(){
 		this._storedFiles = [];
-		this._options.listElement.innerHTML = "";
+        if (this._options.listElement !== null){
+            this._options.listElement.innerHTML = "";
+        }
 	},
 	_createUploadButton: function(element){
 		var self = this;


### PR DESCRIPTION
My simple fix merely avoids the error, it does not clear the list. Since I use jQuery in the relevant project, I do that with $('#file-upload .qq-upload-list').empty() in my own code, but you probably want to handle that case as well.
