### PR TITLE
setParams can take a function as argument

### DIFF
--- a/client/fileuploader.js
+++ b/client/fileuploader.js
@@ -344,7 +344,7 @@ qq.FileUploaderBasic.prototype = {
 			this._filesInProgress++;
 			var params = this._options.params;
 			if (typeof params === 'function') {
-				params = params();
+				params = params(this._storedFiles[i]);
 			} 
 			this._handler.upload(this._storedFiles[i], params);
 		}


### PR DESCRIPTION
I changed setParams so it will take a function as an argument. This function is then called to get the parameters at a later stage. This allows delayed setting of the parameters, even later than onSubmit. I use this with autoUpload set to false, a fileTemplate that allows you to specify a description for the file, and a setParams function that fetches this description just as the file is uploaded. Using onSubmit did not work for this (it fires too early) and onUpload is too late to modify params.
