### PR TITLE
Fix the multipart name issue when use option {encoding: "multipart"} 

### DIFF
--- a/client/fileuploader.js
+++ b/client/fileuploader.js
@@ -1420,7 +1420,7 @@ qq.extend(qq.UploadHandlerXhr.prototype, {
         xhr.setRequestHeader("X-File-Name", encodeURIComponent(name));
         if (this._options.encoding == 'multipart') {
             var formData = new FormData();
-            formData.append(name, file);
+            formData.append(this._options.inputName, file);
             file = formData;
         } else {
             xhr.setRequestHeader("Content-Type", "application/octet-stream");


### PR DESCRIPTION
There is an issue in original impl when use multipart as the encoding options. File name is used as the multipart data name instead of inputName.

For example, following data will be sent out

```
-----------------------------11538186919912
Content-Disposition: form-data; name="DAA.01.txt"; filename="DAA.01.txt"
Content-Type: text/plain
```

Which should be 

```
-----------------------------11538186919912
Content-Disposition: form-data; name="inputFile"; filename="DAA.01.txt"
Content-Type: text/plain
```
