### PR TITLE
file-uploader now tries to parse server response as JSON even if HTTP status code is not 200

### DIFF
--- a/client/fileuploader.js
+++ b/client/fileuploader.js
@@ -1448,27 +1448,26 @@ qq.extend(qq.UploadHandlerXhr.prototype, {
 
         var name = this.getName(id);
         var size = this.getSize(id);
+        var response; //the parsed JSON response from the server, or the empty object if parsing failed.
 
         this._options.onProgress(id, name, size, size);
 
-        if (xhr.status == 200){
-            this.log("xhr - server response received");
-            this.log("responseText = " + xhr.responseText);
-            var response;
-            try {
-                if (typeof JSON.parse === "function") {
-                    response = JSON.parse(xhr.responseText);
-                } else {
-                    response = eval("(" + xhr.responseText + ")");
-                }
-            } catch(err){
-                response = {};
+        this.log("xhr - server response received");
+        this.log("responseText = " + xhr.responseText);
+
+        try {
+            if (typeof JSON.parse === "function") {
+                response = JSON.parse(xhr.responseText);
+            } else {
+                response = eval("(" + xhr.responseText + ")");
             }
-            this._options.onComplete(id, name, response);
-        } else {
-            this._options.onError(id, name, xhr);
-            this._options.onComplete(id, name, {});
+        } catch(err){
+            response = {};
         }
+        if (xhr.status !== 200){
+            this._options.onError(id, name, xhr);
+        }
+        this._options.onComplete(id, name, response);
 
         this._files[id] = null;
         this._xhrs[id] = null;


### PR DESCRIPTION
In our project, we needed to have the server return structured error data as JSON for further processing on the client side, but the original version of file-uploader only tries to parse the server response if the status code was 200.

This change now makes file-uploader attempt to parse the server-response regardless of the status code, falling back to the empty response object if the parse was unsuccessful (which is what it did previously in the case of an unparsable HTTP 200 response).
