### PR TITLE
added support for localizing 'is' and 'are' strings

### DIFF
--- a/client/fileuploader.js
+++ b/client/fileuploader.js
@@ -297,14 +297,12 @@ qq.FileUploaderBasic = function(o){
         onError: function(id, fileName, reason) {},
         // messages
         messages: {
-            typeError: "{file} has an invalid extension. Only {extensions} {isAre} allowed.",
+            typeError: "{file} has an invalid extension. Valid extension(s): {extensions}.",
             sizeError: "{file} is too large, maximum file size is {sizeLimit}.",
             minSizeError: "{file} is too small, minimum file size is {minSizeLimit}.",
             emptyError: "{file} is empty, please select files again without it.",
             noFilesError: "No files to upload.",
-            onLeave: "The files are being uploaded, if you leave now the upload will be cancelled.",
-            is: "is",
-            are: "are"
+            onLeave: "The files are being uploaded, if you leave now the upload will be cancelled."
         },
         showMessage: function(message){
             alert(message);
@@ -526,7 +524,6 @@ qq.FileUploaderBasic.prototype = {
         r('{extensions}', extensions);
         r('{sizeLimit}', this._formatSize(this._options.sizeLimit));
         r('{minSizeLimit}', this._formatSize(this._options.minSizeLimit));
-        r('{isAre}', extensions.indexOf(",") != -1 ? this._options.messages.are : this._options.messages.is);
 
         this._options.onError(null, fileName, message);
         this._options.showMessage(message);


### PR DESCRIPTION
This fix is simple but needed :)
Allow users to provide translations for 'is' and 'are' messages
