### PR TITLE
Fix cancel handler

### DIFF
--- a/client/fileuploader.js
+++ b/client/fileuploader.js
@@ -920,7 +920,9 @@ qq.extend(qq.FileUploader.prototype, {
                 qq.preventDefault(e);
 
                 var item = target.parentNode;
-                while(item.qqFileId == undefined) { item = target = target.parentNode; }
+                while(item.qqFileId == undefined) {
+                    item = target = target.parentNode;
+                }
 
                 self._handler.cancel(item.qqFileId);
                 qq.remove(item);


### PR DESCRIPTION
Cancel handler not work if `fileTemplate` root node is different of cancel `parentNode`, maybe it's not good idea use a `while` but if file template root node always have a `qqFileId` [line 886](https://github.com/korzhyk/file-uploader/blob/b4defd5e3f05b70f1b746aa6ba1605c7bfe63fab/client/fileuploader.js#L886) property why not?
