### PR TITLE
Change in default size-limit and make upload-path more flexible

### DIFF
--- a/server/php.php
+++ b/server/php.php
@@ -127,12 +127,10 @@ class qqFileUploader {
         
         $this->checkServerSettings();       
 
-		if (isset($_FILES['qqfile'])) {
-			$this->file = new qqUploadedFileForm();
-		} else if (isset($_GET['qqfile'])) {
-			$this->file = new qqUploadedFileXhr();
+        if (strpos(strtolower($_SERVER['CONTENT_TYPE']), 'multipart/') === 0) {
+            $this->file = new qqUploadedFileForm();
         } else {
-            $this->file = false; 
+            $this->file = new qqUploadedFileXhr();
         }
     }
     


### PR DESCRIPTION
- Added documentation
- set default sizeLimit to server max-upload size
- make upload-path more flxiple: add a trainling slash
- I have added a fix for the PHP issue #347. Have tested with single file uploads on chromium, IE 8 and Firefox.
