### PR TITLE
Give onComplete more response data

### DIFF
--- a/client/fileuploader.js
+++ b/client/fileuploader.js
@@ -1594,7 +1594,7 @@ qq.extend(qq.UploadHandlerXhr.prototype, {
                 response = eval("(" + xhr.responseText + ")");
             }
         } catch(err){
-            response = {success: false, text: responseText};
+            response = {success: false, text: xhr.responseText};
         }
         if (xhr.status !== 200){
             this._options.onError(id, name, "XHR returned response code " + xhr.status);


### PR DESCRIPTION
Add support for no JSON response from the server, _options.onComplete can get response text.
