### PR TITLE
Move templates into HTML file(s)

### DIFF
--- a/client/js/jquery.createfineuploader.plugin.js
+++ b/client/js/jquery.createfineuploader.plugin.js
@@ -1,7 +1,9 @@
 (function($){
     $.fn.createFineUploader = function(ops){
-        var reg = />[\r\n\s]+</g, tpl, list;
-        if( list = this.find('.qq-upload-list') && list.length ) {
+        var reg = />[\r\n\s]+</g,
+            list = this.find('.qq-upload-list'),
+            tpl;
+        if( list.length ) {
             tpl = list.html().replace(reg, '><');
             ops.fileTemplate = $.trim(tpl);
             list.empty();


### PR DESCRIPTION
The difference between $.fn.fineUploader and $.fn.createFineUploader that mine just prepare options for native qq.FineUploader constructor and return native qq.FineUploader object. I make this plugin because template options should be in html file, not in js.

For example

``` html
<div id="fine-uploader" class="qq-uploader">
    <button type="button" class="qq-upload-button">Select file</button>
    <div class="qq-upload-drop-area"></div>
    <ul class="qq-upload-list">
        <li>
            <span class="qq-upload-file"></span>
            <div class="toolbar">
                <span class="qq-upload-size"></span>
                <div class="qq-progress-bar"></div>
                <span class="qq-upload-spinner"></span>
                <span class="qq-upload-finished"></span>
                <a class="qq-upload-cancel" href="#">{cancelButtonText}</a>
                <a class="qq-upload-retry" href="#">{retryButtonText}</a>
                <span class="qq-upload-status-text">{statusText}</span>
            </div>
        </li>
    </ul>
</div>
```

and as usually

``` javascript
var uploader = $('#fine-uploader').createFineUploader({
    request: {
        endpoint: '/uploadFile'
    }
});
```

After that you will get uploader with 

``` javascript
element:      $('#fine-uploader').get(0),
fileTemplate: '<li><span class="qq-upload-file"></span>.....</li>',
template:     '<button type="button" class="qq-upload-button">.....'
```

As for me it's much better keep all template markup in html then write manually

``` javascript
fileTemplate:
    '<li>'+
        '<span class="qq-upload-file"></span>'+
        '....' +
    '</li>',
```

Maybe will be better if just add my code to $.fn.fineUploader ?

<!---
@huboard:{"order":860.5}
-->
