### PR TITLE
Setter for upload name

### DIFF
--- a/server/php.php
+++ b/server/php.php
@@ -112,7 +112,7 @@ class qqFileUploader {
 	 * @param array $allowedExtensions; defaults to an empty array
 	 * @param int $sizeLimit; defaults to the server's upload_max_filesize setting
 	 */
-    function __construct(array $allowedExtensions = null, $sizeLimit = null){
+    public function __construct(array $allowedExtensions = null, $sizeLimit = null){
     	if($allowedExtensions===null) {
     		$allowedExtensions = array();
     	}
@@ -135,12 +135,22 @@ class qqFileUploader {
     }
     
     /**
+     * Set the name of the uploaded file
+     * @param string $uploadName
+     */
+    public function setUploadName($uploadName){
+    	$this->uploadName = $uploadName;
+    }
+    
+    
+    /**
      * Get the name of the uploaded file
      * @return string
      */
 	public function getUploadName(){
 		if( isset( $this->uploadName ) )
 			return $this->uploadName;
+		return '';
 	}
 	
 	/**
@@ -150,6 +160,7 @@ class qqFileUploader {
 	public function getName(){
 		if ($this->file)
 			return $this->file->getName();
+		return '';
 	}
     
 	/**
@@ -206,7 +217,7 @@ class qqFileUploader {
             return array('error' => 'File is too large');
         }
         
-        $pathinfo = pathinfo($this->file->getName());
+        $pathinfo = pathinfo($this->getName());
         $filename = $pathinfo['filename'];
         //$filename = md5(uniqid());
         $ext = @$pathinfo['extension'];		// hide notices if extension is empty
@@ -218,16 +229,17 @@ class qqFileUploader {
         
         $ext = ($ext == '') ? $ext : '.' . $ext;
         
+        $this->setUploadName($filename . $ext);
+        
         if(!$replaceOldFile){
             /// don't overwrite previous files that were uploaded
-            while (file_exists($uploadDirectory . DIRECTORY_SEPARATOR . $filename . $ext)) {
+            while (file_exists($uploadDirectory . DIRECTORY_SEPARATOR . $this->getUploadName())) {
                 $filename .= rand(10, 99);
+                $this->setUploadName($filename . $ext);
             }
         }
         
-		$this->uploadName = $filename . $ext;
-		
-        if ($this->file->save($uploadDirectory . DIRECTORY_SEPARATOR . $filename . $ext)){
+        if ($this->file->save($uploadDirectory . DIRECTORY_SEPARATOR . $this->getUploadName())){
             return array('success'=>true);
         } else {
             return array('error'=> 'Could not save uploaded file.' .


### PR DESCRIPTION
Example:

MySecurityUploader extends qqFileUploader
{
    public function setUploadName($uploadName)
    {
        $pathinfo = pathinfo($uploadName);
        $ext = @$pathinfo['extension'];
        $ext = ($ext == '') ? $ext : '.' . $ext;

```
    $this->uploadName = md5(uniqid()).$ext;
}
```

}
