### PR TITLE
Content-Type example for php.php #346

### DIFF
--- a/server/php.php
+++ b/server/php.php
@@ -16,6 +16,7 @@ $uploader = new qqFileUploader($allowedExtensions, $sizeLimit);
 $result = $uploader->handleUpload('uploads/');
 
 // to pass data through iframe you will need to encode all html tags
+header("Content-Type: text/plain");
 echo htmlspecialchars(json_encode($result), ENT_NOQUOTES);
 
 /******************************************/


### PR DESCRIPTION
Updated the php.php example (in the comments) to setting the header's content-type to text/plain (see <a href="https://github.com/valums/file-uploader/issues/346">#346</a>)
