### PR TITLE
Checks if $_SERVER['CONTENT_TYPE'] exists

### DIFF
--- a/server/php.php
+++ b/server/php.php
@@ -106,18 +106,18 @@ class qqFileUploader {
     private $allowedExtensions;
     private $sizeLimit;
     private $file;
-	private $uploadName;
+    private $uploadName;
 
-	/**
-	 * @param array $allowedExtensions; defaults to an empty array
-	 * @param int $sizeLimit; defaults to the server's upload_max_filesize setting
-	 */
+    /**
+     * @param array $allowedExtensions; defaults to an empty array
+     * @param int $sizeLimit; defaults to the server's upload_max_filesize setting
+     */
     function __construct(array $allowedExtensions = null, $sizeLimit = null){
-    	if($allowedExtensions===null) {
-    		$allowedExtensions = array();
+        if($allowedExtensions===null) {
+            $allowedExtensions = array();
     	}
     	if($sizeLimit===null) {
-    		$sizeLimit = $this->toBytes(ini_get('upload_max_filesize'));
+    	    $sizeLimit = $this->toBytes(ini_get('upload_max_filesize'));
     	}
     	        
         $allowedExtensions = array_map("strtolower", $allowedExtensions);
@@ -127,7 +127,9 @@ class qqFileUploader {
         
         $this->checkServerSettings();       
 
-        if (strpos(strtolower($_SERVER['CONTENT_TYPE']), 'multipart/') === 0) {
+        if(!isset($_SERVER['CONTENT_TYPE'])) {
+            $this->file = false;	
+        } else if (strpos(strtolower($_SERVER['CONTENT_TYPE']), 'multipart/') === 0) {
             $this->file = new qqUploadedFileForm();
         } else {
             $this->file = new qqUploadedFileXhr();
@@ -138,24 +140,24 @@ class qqFileUploader {
      * Get the name of the uploaded file
      * @return string
      */
-	public function getUploadName(){
-		if( isset( $this->uploadName ) )
-			return $this->uploadName;
-	}
+    public function getUploadName(){
+        if( isset( $this->uploadName ) )
+            return $this->uploadName;
+    }
 	
-	/**
-	 * Get the original filename
-	 * @return string filename
-	 */
-	public function getName(){
-		if ($this->file)
-			return $this->file->getName();
-	}
+    /**
+     * Get the original filename
+     * @return string filename
+     */
+    public function getName(){
+        if ($this->file)
+            return $this->file->getName();
+    }
     
-	/**
-	 * Internal function that checks if server's may sizes match the
-	 * object's maximum size for uploads
-	 */
+    /**
+     * Internal function that checks if server's may sizes match the
+     * object's maximum size for uploads
+     */
     private function checkServerSettings(){        
         $postSize = $this->toBytes(ini_get('post_max_size'));
         $uploadSize = $this->toBytes(ini_get('upload_max_filesize'));        
@@ -181,12 +183,12 @@ class qqFileUploader {
         return $val;
     }
     
-	/**
-	 * Handle the uploaded file
-	 * @param string $uploadDirectory
-	 * @param string $replaceOldFile=true
-	 * @returns array('success'=>true) or array('error'=>'error message')
-	 */
+    /**
+     * Handle the uploaded file
+     * @param string $uploadDirectory
+     * @param string $replaceOldFile=true
+     * @returns array('success'=>true) or array('error'=>'error message')
+     */
     function handleUpload($uploadDirectory, $replaceOldFile = FALSE){
         if (!is_writable($uploadDirectory)){
             return array('error' => "Server error. Upload directory isn't writable.");
@@ -225,7 +227,7 @@ class qqFileUploader {
             }
         }
         
-		$this->uploadName = $filename . $ext;
+        $this->uploadName = $filename . $ext;
 		
         if ($this->file->save($uploadDirectory . DIRECTORY_SEPARATOR . $filename . $ext)){
             return array('success'=>true);


### PR DESCRIPTION
<a href="https://github.com/valums/file-uploader/pull/442">#442</a> references this same problem but uses throw error (where this change returns a more friendly error)

This checks the content type and sets $this->file = false if it's not set

To address the question raised in <a href="https://github.com/valums/file-uploader/pull/442">#442</a>:
if $_SERVER['CONTENT_TYPE'] isn't set it causes php to fatal error (IE: the user tries to run the script w/o an uploaded file)

the code was already their to check if $this->file = false to output an error

This was tested on IE9 and Chrome 23.

I also reformatted some of the code to maintain consistency (some of the lines used tabs while most of them used 4 spaces, so I converted all the tabs to 4 spaces)
