### PR TITLE
Re-enable the drag/drop functionality for non-multi upload when user drags more than 1 file

### DIFF
--- a/client/js/dnd.js
+++ b/client/js/dnd.js
@@ -74,6 +74,7 @@ qq.DragAndDrop = function(o) {
 
         if (dataTransfer.files.length > 1 && !options.multiple) {
             options.callbacks.error('tooManyFilesError', "");
+            dz.dropDisabled(false);
         }
         else {
             droppedFiles = [];


### PR DESCRIPTION
Bug: Drag/drop is locked after dropping 2 or more files on a single-file upload dropzone

I couldn't find a way to hide the "Processing dropped files..." label though (css class "qq-drop-processing")
