### PR TITLE
Fix create URL using request or deleteFile params 

### DIFF
--- a/client/js/ajax.requester.js
+++ b/client/js/ajax.requester.js
@@ -58,13 +58,15 @@ qq.AjaxRequestor = function(o) {
         var xhr = new XMLHttpRequest(),
             method = options.method,
             params = {},
-            url = createUrl(id);
+            url;
 
         options.onSend(id);
 
         if (requestState[id].paramsStore.getParams) {
             params = requestState[id].paramsStore.getParams(id);
         }
+
+        url = createUrl(id, params);
 
         requestState[id].xhr = xhr;
         xhr.onreadystatechange = getReadyStateChangeHandler(id);

--- a/client/js/uploader.basic.js
+++ b/client/js/uploader.basic.js
@@ -676,10 +676,7 @@ qq.FineUploaderBasic.prototype = {
                     qq.extend(paramsCopy, paramsStore[fileId]);
                 }
                 else {
-                    if(type == "request")
-                        qq.extend(paramsCopy, self._options.request.params);
-                    else
-                        qq.extend(paramsCopy, self._options.deleteFile.params);
+                    qq.extend(paramsCopy, self._options[type].params);
                 }
 
                 return paramsCopy;

--- a/client/js/uploader.basic.js
+++ b/client/js/uploader.basic.js
@@ -109,8 +109,9 @@ qq.FineUploaderBasic = function(o){
     this._retryTimeouts = [];
     this._preventRetries = [];
 
-    this._paramsStore = this._createParamsStore();
-    this._deleteFileParamsStore = this._createParamsStore();
+    this._paramsStore = this._createParamsStore("request");
+    this._deleteFileParamsStore = this._createParamsStore("deleteFile");
+
     this._endpointStore = this._createEndpointStore();
 
     this._handler = this._createUploadHandler();
@@ -656,7 +657,7 @@ qq.FineUploaderBasic.prototype = {
 
         return fileDescriptors;
     },
-    _createParamsStore: function() {
+    _createParamsStore: function(type) {
         var paramsStore = {},
             self = this;
 
@@ -675,7 +676,10 @@ qq.FineUploaderBasic.prototype = {
                     qq.extend(paramsCopy, paramsStore[fileId]);
                 }
                 else {
-                    qq.extend(paramsCopy, self._options.request.params);
+                    if(type == "request")
+                        qq.extend(paramsCopy, self._options.request.params);
+                    else
+                        qq.extend(paramsCopy, self._options.deleteFile.params);
                 }
 
                 return paramsCopy;


### PR DESCRIPTION
Previously, `deleteFile.params` were not being sent with delete requests, even after `setDeleteFileParams()` was called.

In cb51bf53cf4756fda6c757ba8cb24d82a8dd3955 `url` was set with `createUrl(id, params)` without `params` and before `params` were collected.

However, after setting `url` after `params` is set the `request.params` were being sent.

In 693989597cc412d7dd19d98edc66a45d5099815d the method for getting parameters from parameter stores for request and deleteFile needed to be fixed.
