### PR TITLE
add note about padding response for IE

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1159,7 +1159,8 @@ you may want to be aware of when using Fine Uploader:
             <td>If the response code is not 200, and the size of the response is less than 512, or, apparently, sometimes, less
             than 256 bytes, IE replaces the response with a "friendly" error message.  If you insist on returning responses
             with a status code other than 200, you can work around this by instructing IE users to uncheck the "show friendly
-            HTTP error messages" setting.</td>
+            HTTP error messages" setting or by padding the response JSON with whitespace as described
+            [here](http://blogs.msdn.com/b/ieinternals/archive/2010/08/19/http-error-pages-in-internet-explorer.aspx).</td>
             <td>No</td>
         </tr>
         <tr>


### PR DESCRIPTION
I decided to do some digging into IE's "friendly" error issue, and came across [this MSDN article](http://blogs.msdn.com/b/ieinternals/archive/2010/08/19/http-error-pages-in-internet-explorer.aspx) addressing the problem. They suggest padding the response with whitespace until the 512 byte limit has been reached as a way of preserving the usefulness of the HTTP status codes (and without forcing users to change their settings... since I think if users felt comfortable doing this they would probably not be using IE). Would be nice to note this alternate solution in the docs.

Side note: I have "trim trailing whitespace" set in my editor, and noticed that most lines in the readme (and other files) seem to have a bunch of extra whitespace. Any reason for this? Personal preference?
