### PR TITLE
Further fixes to chunked uploading

### DIFF
--- a/server/php/qqFileUploader.php
+++ b/server/php/qqFileUploader.php
@@ -130,10 +130,10 @@ class qqFileUploader {
                 $target = $this->getUniqueTargetPath($uploadDirectory, $name);
                 $this->uploadName = basename($target);
 
-                $target = fopen($target, 'w');
+                $target = fopen($target, 'wb');
 
                 for ($i=0; $i<$totalParts; $i++){
-                    $chunk = fopen($targetFolder.'/'.$i, "rb");
+                    $chunk = fopen($targetFolder.DIRECTORY_SEPARATOR.$i, "rb");
                     stream_copy_to_stream($chunk, $target);
                     fclose($chunk);
                 }
@@ -142,8 +142,7 @@ class qqFileUploader {
                 fclose($target);
 
                 for ($i=0; $i<$totalParts; $i++){
-                    $chunk = fopen($targetFolder.'/'.$i, "r");
-                    unlink($targetFolder.'/'.$i);
+                    unlink($targetFolder.DIRECTORY_SEPARATOR.$i);
                 }
 
                 rmdir($targetFolder);


### PR DESCRIPTION
This patch primarily addresses v3.2, but also a potential bug/memory-leak (the last paragraph) in v3.3.

In 3.2 chunked uploads fail. I noticed that the $chunk (line #136) descriptor is allocated via "w", which is incompatible with reading. The result was a "successful" upload that left something 0 bytes in size.

It's important to specify 'b' with any `fopen()` call for Windows compatibility. Also for OS compatibility, I removed hardcoded slashes in favor of the `DIRECTORY_SEPARATOR` constant.

Also, when unlinking the parts of a chunked upload we don't want an open file handle to linger about.
