### PR TITLE
workaround aggressive minification not playing ball with IE8

### DIFF
--- a/client/js/util.js
+++ b/client/js/util.js
@@ -62,7 +62,8 @@ var qq = function(element) {
          */
         css: function(styles) {
             if (styles.opacity !== null){
-                if (typeof element.style.opacity !== 'string' && typeof(element.filters) !== 'undefined'){
+                var typeofFilters = typeof(element.filters);
+                if (typeof element.style.opacity !== 'string' && typeofFilters !== 'undefined'){
                     styles.filter = 'alpha(opacity=' + Math.round(100 * styles.opacity) + ')';
                 }
             }


### PR DESCRIPTION
I've had an issue when using [uglify](https://github.com/mishoo/UglifyJS2) to compress fine-uploader (as part of a bigger build job) in that it compresses 

``` javascript
typeof something !== 'undefined'
```

to

``` javascript
something!==void 0
```

which is all fine, but when it comes to the following chunk of code

``` javascript
typeof(element.filters) !== 'undefined'
```

in IE8 we get problems. 

`typeof(element.filters)` in IE8 produces (or in my scenario produces) 'unknown', but when evaluating `element.filters` directly a 'Member not found' exception is thrown, killing the entire script.

Therefore I've put in a workaround that forces the typeof to remain in the minified code meaning everything works fine. Note this isn't a problem with the gradle minification. It leaves the typeof intact anyway.
