### PR TITLE
check for styles.opacity being undefined in qq.css

### DIFF
--- a/client/js/util.js
+++ b/client/js/util.js
@@ -61,7 +61,7 @@ var qq = function(element) {
          * Fixes opacity in IE6-8.
          */
         css: function(styles) {
-            if (styles.opacity !== null  && (typeof styles.opacity !== 'undefined')){
+            if (styles.opacity != null){
                 if (typeof element.style.opacity !== 'string' && typeof(element.filters) !== 'undefined'){
                     styles.filter = 'alpha(opacity=' + Math.round(100 * styles.opacity) + ')';
                 }


### PR DESCRIPTION
This corrects an issue we ran into using fineuploader basic with IE7 where, if you inspect the DOM element that is passed to fineuploader as `button` you can see that the element has inline style information something like: `filter: alpha(NaN)`. 

[This Stack Overflow thread](http://stackoverflow.com/a/15505748) suggested this fix and we implemented it and found it corrects the issue. @rnicholus suggested in that same thread to use a nested element, which we did not try. I'm of the opinion that if this affected us as well as the original asker (and it took us a good 30 minutes to discover what was going on) that it's worth correcting since the project states it supports IE7.
