### PR TITLE
2 - Hide add button when itemLimit is reached

### DIFF
--- a/client/js/uploader.basic.js
+++ b/client/js/uploader.basic.js
@@ -601,6 +601,12 @@ qq.FineUploaderBasic.prototype = {
         if (!this._options.autoUpload && storedItemIndex >= 0) {
             this._storedIds.splice(storedItemIndex, 1);
         }
+
+        var itemLimit = this._options.validation.itemLimit;
+        if (itemLimit > 0 && itemLimit > this._netUploadedOrQueued) {
+            var btn = this._find(this._element, 'button');
+            btn.style.display = '';
+        }
     },
     _isDeletePossible: function() {
         return (this._options.deleteFile.enabled &&
@@ -765,6 +771,12 @@ qq.FineUploaderBasic.prototype = {
         }
         else {
             this._storeForLater(id);
+        }
+
+        var itemLimit = this._options.validation.itemLimit;
+        if (itemLimit > 0 && itemLimit <= this._netUploadedOrQueued) {
+            var btn = this._find(this._element, 'button');
+            qq(btn).hide();
         }
     },
     _storeForLater: function(id) {


### PR DESCRIPTION
I've added some simple code to hide the add button / upload button when itemLimit is reached. If you'd like I could add an option to turn this feature on/off as well, but I don't really see why you'd want to have the button visible after the limit is reached.

<!---
@huboard:{"order":6.68359375}
-->
