### PR TITLE
1 - Add an UploadedChunk event callback

### DIFF
--- a/client/js/handler.base.js
+++ b/client/js/handler.base.js
@@ -51,6 +51,7 @@ qq.UploadHandler = function(o, namespace) {
         onCancel: function(id, fileName){},
         onUpload: function(id, fileName){},
         onUploadChunk: function(id, fileName, chunkData){},
+        onUploadedChunk: function(id, fileName, response, xhr){},
         onAutoRetry: function(id, fileName, response, xhr){},
         onResume: function(id, fileName, chunkData){},
         onUuidChanged: function(id, newUuid){}

--- a/client/js/traditional/handler.xhr.js
+++ b/client/js/traditional/handler.xhr.js
@@ -203,7 +203,9 @@ qq.UploadHandlerXhr = function(options, uploadCompleteCallback, onUuidChanged, l
 
     function handleSuccessfullyCompletedChunk(id, response, xhr) {
         var chunkIdx = fileState[id].remainingChunkIdxs.shift(),
-            chunkData = internalApi.getChunkData(id, chunkIdx);
+            chunkData = internalApi.getChunkData(id, chunkIdx),
+            name = publicApi.getName(id);
+        options.onUploadedChunk(id, name, response, xhr);
 
         fileState[id].attemptingResume = false;
         fileState[id].loaded += chunkData.size + getLastRequestOverhead(id);

--- a/client/js/uploader.basic.api.js
+++ b/client/js/uploader.basic.api.js
@@ -456,6 +456,10 @@ qq.basePrivateApi = {
                     self._onProgress(id, name, loaded, total);
                     self._options.callbacks.onProgress(id, name, loaded, total);
                 },
+                onUploadedChunk: function(id, name, response, xhr){
+                    self._onUploadedChunk(id, name, response, xhr);
+                    self._options.callbacks.onUploadedChunk(id, name, response, xhr);
+                },
                 onComplete: function(id, name, result, xhr){
                     var retVal = self._onComplete(id, name, result, xhr);
 
@@ -613,6 +617,10 @@ qq.basePrivateApi = {
     },
 
     _onProgress: function(id, name, loaded, total) {
+        //nothing to do yet in core uploader
+    },
+
+    _onUploadedChunk: function(id, name, response, xhr) {
         //nothing to do yet in core uploader
     },
 

--- a/client/js/uploader.basic.js
+++ b/client/js/uploader.basic.js
@@ -33,6 +33,7 @@ qq.FineUploaderBasic = function(o) {
             onCancel: function(id, name){},
             onUpload: function(id, name){},
             onUploadChunk: function(id, name, chunkData){},
+            onUploadedChunk: function(id, name, responseJSON, maybeXhr){},
             onResume: function(id, fileName, chunkData){},
             onProgress: function(id, name, loaded, total){},
             onError: function(id, name, reason, maybeXhrOrXdr) {},


### PR DESCRIPTION
It would be great to get a callback after a chunk has been uploaded. This is to allow the response from the server to be processed by the client, useful when the server sends back custom info for each chunk. 

See http://stackoverflow.com/questions/19628292/fineuploader-chunk-uploaded-get-response-data-for-each-chunk-callback 

<!---
@huboard:{"order":65.56321716308594}
-->
