### PR TITLE
Exception when creating a drag and drop zone for S3 uploader

### DIFF
--- a/client/js/jquery-dnd.js
+++ b/client/js/jquery-dnd.js
@@ -40,8 +40,7 @@
     }
 
     function addCallbacks(transformedOpts) {
-        var callbacks = transformedOpts.callbacks = {},
-            dndInst = new qq.FineUploaderBasic();
+        var callbacks = transformedOpts.callbacks = {};
 
         $.each(new qq.DragAndDrop.callbacks(), function(prop, func) {
             var name = prop,


### PR DESCRIPTION
I have the S3 version of fineuploader with the drag and drop module. When creating the dropzone via `element.fineUploaderDnd(opts);` I get an exception:

```
TypeError: undefined is not a function
    at determineHandlerImpl (http://10.1.2.2/assets/scripts/govhub-deps.js:6931:23)
    at new qq.UploadHandler (http://10.1.2.2/assets/scripts/govhub-deps.js:7070:5)
    at Object.qq.basePrivateApi._createUploadHandler (http://10.1.2.2/assets/scripts/govhub-deps.js:5301:20)
    at Object.qq.FineUploaderBasic (http://10.1.2.2/assets/scripts/govhub-deps.js:6421:30)
    at addCallbacks (http://10.1.2.2/assets/scripts/govhub-deps.js:11261:23)
    at init (http://10.1.2.2/assets/scripts/govhub-deps.js:11231:9)
```

I've traced it back to the call to `new qq.FineUploaderBasic()` in `query-dnd.js` - which presumably would want to be `qq.s3.FineUploaderBasic()` in the S3 case - however the variable `dndInst` never gets used so I think it can just be deleted.

<!---
@huboard:{"order":27.078951278701425,"custom_state":""}
-->
