### PR TITLE
onProgress event should send the name parameter

### DIFF
--- a/client/js/upload-handler/xhr.upload.handler.js
+++ b/client/js/upload-handler/xhr.upload.handler.js
@@ -401,6 +401,7 @@ qq.XhrUploadHandler = function(spec) {
 
         _registerProgressHandler: function(id, chunkIdx, chunkSize) {
             var xhr = handler._getXhr(id, chunkIdx),
+                name = getName(id),
                 progressCalculator = {
                     simple: function(loaded, total) {
                         var fileSize = getSize(id);


### PR DESCRIPTION
The `onProgress` event sends the `name` parameter as an empty string. I've tested this on 5.0.3 using the s3 client, but I expect this is broken for all clients.

This appears have broken in 74f3ca78b2ee65e7d344acabb4805fb120ebfd84.

I was unable to find a test that executed the function in question.
