### PR TITLE
fixes bug where large amount of uploads races ahead of UI

### DIFF
--- a/client/js/templating.js
+++ b/client/js/templating.js
@@ -213,8 +213,8 @@ qq.Templating = function(spec) {
             beforeEl = parentEl.firstChild;
 
         if (index > 0) {
-            beforeEl = qq(parentEl).children()[index].nextSibling;
-
+            var child = qq(parentEl).children()[index];
+            child && (beforeEl = child.nextSibling);
         }
 
         parentEl.insertBefore(el, beforeEl);


### PR DESCRIPTION
We have a bug where, when a large amount of files being uploaded (go to a folder with lots of files, select all) the update goes to the upload tray but the element doesn't exist there yet so the prepend function in templating.js throws an exception and all subsequent files fail to submit to the uploader.

    qq(parentEl).children()[index].nextSibling;

can not call nextSibling of undefined.

This fix is just a simple guard to avoid this and allow all files to be submitted.

Tested on Chrome, Firefox and Safari

<!---
@huboard:{"order":25.25}
-->
