### PR TITLE
feat(client/js/*/uploader.basic.js): #1252 - Allow to change successEndpoint per upload

### DIFF
--- a/client/js/azure/uploader.basic.js
+++ b/client/js/azure/uploader.basic.js
@@ -48,6 +48,7 @@
         qq.FineUploaderBasic.call(this, options);
 
         this._uploadSuccessParamsStore = this._createStore(this._options.uploadSuccess.params);
+        this._uploadSuccessEndpointStore = this._createStore(this._options.uploadSuccess.endpoint);
 
          // This will hold callbacks for failed uploadSuccess requests that will be invoked on retry.
         // Indexed by file ID.

--- a/client/js/non-traditional-common/uploader.basic.api.js
+++ b/client/js/non-traditional-common/uploader.basic.api.js
@@ -8,6 +8,9 @@
     qq.nonTraditionalBasePublicApi = {
         setUploadSuccessParams: function(params, id) {
             this._uploadSuccessParamsStore.set(params, id);
+        },
+        setUploadSuccessEndpoint: function(endpoint, id) {
+            this._uploadSuccessEndpointStore.set(endpoint, id);
         }
     };
 
@@ -32,7 +35,7 @@
             var success = result.success ? true : false,
                 self = this,
                 onCompleteArgs = arguments,
-                successEndpoint = this._options.uploadSuccess.endpoint,
+                successEndpoint = this._uploadSuccessEndpointStore.get(id),
                 successCustomHeaders = this._options.uploadSuccess.customHeaders,
                 cors = this._options.cors,
                 promise = new qq.Promise(),

--- a/client/js/s3/uploader.basic.js
+++ b/client/js/s3/uploader.basic.js
@@ -84,6 +84,7 @@
         qq.FineUploaderBasic.call(this, options);
 
         this._uploadSuccessParamsStore = this._createStore(this._options.uploadSuccess.params);
+        this._uploadSuccessEndpointStore = this._createStore(this._options.uploadSuccess.endpoint);
 
         // This will hold callbacks for failed uploadSuccess requests that will be invoked on retry.
         // Indexed by file ID.
@@ -124,6 +125,10 @@
 
         setUploadSuccessParams: function(params, id) {
             this._uploadSuccessParamsStore.set(params, id);
+        },
+
+        setUploadSuccessEndpoint: function(endpoint, id) {
+            this._uploadSuccessEndpointStore.set(endpoint, id);
         },
 
         setCredentials: function(credentials, ignoreEmpty) {

--- a/client/js/s3/uploader.basic.js
+++ b/client/js/s3/uploader.basic.js
@@ -123,14 +123,6 @@
             this._failedSuccessRequestCallbacks = [];
         },
 
-        setUploadSuccessParams: function(params, id) {
-            this._uploadSuccessParamsStore.set(params, id);
-        },
-
-        setUploadSuccessEndpoint: function(endpoint, id) {
-            this._uploadSuccessEndpointStore.set(endpoint, id);
-        },
-
         setCredentials: function(credentials, ignoreEmpty) {
             if (credentials && credentials.secretKey) {
                 if (!credentials.accessKey) {


### PR DESCRIPTION
I implemented the feature request #1252. I basically cloned the _uploadSuccessParams_ behavior, as indicated by @fschwahn in his comment. This code was tested with S3, but **not with azure**.

To change the uploadSuccess endpoint, simply call this method with the new endpoint and the file ID:

``` javascript
myUploader.setUploadSuccessEndpoint("YOUR ENDPOINT", id);
```
