### PR TITLE
Add unprefixed Azure request headers support

### DIFF
--- a/client/js/azure/util.js
+++ b/client/js/azure/util.js
@@ -6,11 +6,41 @@ qq.azure.util = qq.azure.util || (function() {
     return {
         AZURE_PARAM_PREFIX: "x-ms-meta-",
 
+        /** Create Prefixed request headers which are appropriate for Azure.
+         *
+         * If the request header is appropriate for Azure (e.g. Cache-Control) then pass
+         * it along without a metadata prefix. For all other request header parameter names,
+         * apply qq.azure.util.AZURE_PARAM_PREFIX before the name.
+         *
+         * @param name Name of the Request Header parameter to construct a (possibly) prefixed name.
+         * @returns {String} A valid Request Header parameter name.
+         */
+        _getPrefixedParamName: function (name) {
+            switch (name)
+            {
+                //
+                // Valid request headers (not sent by fine-uploader) which should be returned as-is (case-sensitive)
+                // see: https://msdn.microsoft.com/en-us/library/azure/dd179451.aspx
+                //
+                case "Cache-Control":
+                case "Content-Disposition":
+                case "Content-Encoding":
+                case "Content-MD5":
+                case "x-ms-blob-content-encoding":
+                case "x-ms-blob-content-disposition":
+                case "x-ms-blob-content-md5":
+                case "x-ms-blob-cache-control":
+                    return name;
+                default:
+                    return qq.azure.util.AZURE_PARAM_PREFIX + name;
+            }
+        },
+
         getParamsAsHeaders: function(params) {
             var headers = {};
 
             qq.each(params, function(name, val) {
-                var headerName = qq.azure.util.AZURE_PARAM_PREFIX + name;
+                var headerName = qq.azure.util._getPrefixedParamName(name);
 
                 if (qq.isFunction(val)) {
                     headers[headerName] = encodeURIComponent(String(val()));

--- a/client/js/azure/util.js
+++ b/client/js/azure/util.js
@@ -36,7 +36,7 @@ qq.azure.util = qq.azure.util || (function() {
             }
         },
 
-        _getPrefixedParamName: function (name) {
+        _getPrefixedParamName: function(name) {
             if (qq.azure.util._paramNameMatchesAzureParameter(name)) {
                 return name;
             }

--- a/client/js/azure/util.js
+++ b/client/js/azure/util.js
@@ -37,10 +37,12 @@ qq.azure.util = qq.azure.util || (function() {
         },
 
         _getPrefixedParamName: function (name) {
-            if (qq.azure.util._paramNameMatchesAzureParameter(name))
+            if (qq.azure.util._paramNameMatchesAzureParameter(name)) {
                 return name;
-            else
+            }
+            else {
                 return qq.azure.util.AZURE_PARAM_PREFIX + name;
+            }
         },
 
         getParamsAsHeaders: function(params) {

--- a/client/js/azure/util.js
+++ b/client/js/azure/util.js
@@ -50,8 +50,8 @@ qq.azure.util = qq.azure.util || (function() {
             var headers = {};
 
             qq.each(params, function(name, val) {
-                var headerName = qq.azure.util._getPrefixedParamName(name);
-                var value = null;
+                var headerName = qq.azure.util._getPrefixedParamName(name),
+                    value = null;
 
                 if (qq.isFunction(val)) {
                     value = String(val());

--- a/client/js/azure/util.js
+++ b/client/js/azure/util.js
@@ -15,7 +15,7 @@ qq.azure.util = qq.azure.util || (function() {
          * @param name Name of the Request Header parameter to construct a (possibly) prefixed name.
          * @returns {String} A valid Request Header parameter name.
          */
-        _getPrefixedParamName: function (name) {
+        _getPrefixedParamName: function(name) {
             switch (name)
             {
                 //

--- a/client/js/azure/util.js
+++ b/client/js/azure/util.js
@@ -6,14 +6,10 @@ qq.azure.util = qq.azure.util || (function() {
     return {
         AZURE_PARAM_PREFIX: "x-ms-meta-",
 
-        /** Create Prefixed request headers which are appropriate for Azure.
-         *
-         * If the request header is appropriate for Azure (e.g. Cache-Control) then pass
-         * it along without a metadata prefix. For all other request header parameter names,
-         * apply qq.azure.util.AZURE_PARAM_PREFIX before the name.
+        /** Test if a request header is actually a known Azure parameter.
          *
          * @param name Name of the Request Header parameter to construct a (possibly) prefixed name.
-         * @returns {String} A valid Request Header parameter name.
+         * @returns {Boolean} Test result.
          */
         _paramNameMatchesAzureParameter: function(name) {
             switch (name)
@@ -36,6 +32,15 @@ qq.azure.util = qq.azure.util || (function() {
             }
         },
 
+        /** Create Prefixed request headers which are appropriate for Azure.
+         *
+         * If the request header is appropriate for Azure (e.g. Cache-Control) then it should be
+         * passed along without a metadata prefix. For all other request header parameter names,
+         * qq.azure.util.AZURE_PARAM_PREFIX should be prepended.
+         *
+         * @param name Name of the Request Header parameter to construct a (possibly) prefixed name.
+         * @returns {String} A valid Request Header parameter name.
+         */
         _getPrefixedParamName: function(name) {
             if (qq.azure.util._paramNameMatchesAzureParameter(name)) {
                 return name;

--- a/client/js/azure/util.js
+++ b/client/js/azure/util.js
@@ -15,7 +15,7 @@ qq.azure.util = qq.azure.util || (function() {
          * @param name Name of the Request Header parameter to construct a (possibly) prefixed name.
          * @returns {String} A valid Request Header parameter name.
          */
-        _getPrefixedParamName: function(name) {
+        _paramNameMatchesAzureParameter: function(name) {
             switch (name)
             {
                 //
@@ -30,10 +30,17 @@ qq.azure.util = qq.azure.util || (function() {
                 case "x-ms-blob-content-disposition":
                 case "x-ms-blob-content-md5":
                 case "x-ms-blob-cache-control":
-                    return name;
+                    return true;
                 default:
-                    return qq.azure.util.AZURE_PARAM_PREFIX + name;
+                    return false;
             }
+        },
+
+        _getPrefixedParamName: function (name) {
+            if (qq.azure.util._paramNameMatchesAzureParameter(name))
+                return name;
+            else
+                return qq.azure.util.AZURE_PARAM_PREFIX + name;
         },
 
         getParamsAsHeaders: function(params) {
@@ -47,6 +54,9 @@ qq.azure.util = qq.azure.util || (function() {
                 }
                 else if (qq.isObject(val)) {
                     qq.extend(headers, qq.azure.util.getParamsAsHeaders(val));
+                }
+                else if (qq.azure.util._paramNameMatchesAzureParameter(name)) {
+                    headers[headerName] = val;
                 }
                 else {
                     headers[headerName] = encodeURIComponent(String(val));

--- a/client/js/azure/util.js
+++ b/client/js/azure/util.js
@@ -6,18 +6,14 @@ qq.azure.util = qq.azure.util || (function() {
     return {
         AZURE_PARAM_PREFIX: "x-ms-meta-",
 
-        /** Test if a request header is actually a known Azure parameter.
+        /** Test if a request header is actually a known Azure parameter. See: https://msdn.microsoft.com/en-us/library/azure/dd179451.aspx
          *
-         * @param name Name of the Request Header parameter to construct a (possibly) prefixed name.
+         * @param name Name of the Request Header parameter.
          * @returns {Boolean} Test result.
          */
         _paramNameMatchesAzureParameter: function(name) {
             switch (name)
             {
-                //
-                // Valid request headers (not sent by fine-uploader) which should be returned as-is (case-sensitive)
-                // see: https://msdn.microsoft.com/en-us/library/azure/dd179451.aspx
-                //
                 case "Cache-Control":
                 case "Content-Disposition":
                 case "Content-Encoding":
@@ -55,18 +51,22 @@ qq.azure.util = qq.azure.util || (function() {
 
             qq.each(params, function(name, val) {
                 var headerName = qq.azure.util._getPrefixedParamName(name);
+                var value = null;
 
                 if (qq.isFunction(val)) {
-                    headers[headerName] = encodeURIComponent(String(val()));
+                    value = String(val());
                 }
                 else if (qq.isObject(val)) {
                     qq.extend(headers, qq.azure.util.getParamsAsHeaders(val));
                 }
-                else if (qq.azure.util._paramNameMatchesAzureParameter(name)) {
-                    headers[headerName] = val;
-                }
                 else {
-                    headers[headerName] = encodeURIComponent(String(val));
+                    value = String(val);
+                }
+
+                if (qq.azure.util._paramNameMatchesAzureParameter(name)) {
+                    headers[headerName] = value;
+                } else {
+                    headers[headerName] = encodeURIComponent(value);
                 }
             });
 

--- a/client/js/azure/util.js
+++ b/client/js/azure/util.js
@@ -63,10 +63,12 @@ qq.azure.util = qq.azure.util || (function() {
                     value = String(val);
                 }
 
-                if (qq.azure.util._paramNameMatchesAzureParameter(name)) {
-                    headers[headerName] = value;
-                } else {
-                    headers[headerName] = encodeURIComponent(value);
+                if (value !== null) {
+                    if (qq.azure.util._paramNameMatchesAzureParameter(name)) {
+                        headers[headerName] = value;
+                    } else {
+                        headers[headerName] = encodeURIComponent(value);
+                    }
                 }
             });
 

--- a/test/unit/azure/simple-file-uploads.js
+++ b/test/unit/azure/simple-file-uploads.js
@@ -392,8 +392,7 @@ if (qqtest.canDownloadFileAsBlob) {
             );
             
             var params = {
-                "foo1": "bar", 
-                
+                "foo1": "bar",
                 "Content-Encoding": "1rawvalue==" ,
                 "Content-Disposition": "2rawvalue==",
                 "Content-MD5": "3rawvalue==",

--- a/test/unit/azure/simple-file-uploads.js
+++ b/test/unit/azure/simple-file-uploads.js
@@ -399,7 +399,7 @@ if (qqtest.canDownloadFileAsBlob) {
                 "Cache-Control": "4rawvalue==",
                 "x-ms-blob-content-encoding": "5rawvalue==",
                 "x-ms-blob-content-disposition": "6rawvalue==",
-                "x-ms-blob-content-md5": "7rawvalue==",
+                "x-ms-blob-content-md5": function() { return "7rawvalue=="; },
                 "x-ms-blob-cache-control": "8rawvalue=="
             };
             
@@ -420,7 +420,7 @@ if (qqtest.canDownloadFileAsBlob) {
                     assert.equal(uploadRequest.requestHeaders["Cache-Control"], params["Cache-Control"]);
                     assert.equal(uploadRequest.requestHeaders["x-ms-blob-content-encoding"], params["x-ms-blob-content-encoding"]);
                     assert.equal(uploadRequest.requestHeaders["x-ms-blob-content-disposition"], params["x-ms-blob-content-disposition"]);
-                    assert.equal(uploadRequest.requestHeaders["x-ms-blob-content-md5"], params["x-ms-blob-content-md5"]);
+                    assert.equal(uploadRequest.requestHeaders["x-ms-blob-content-md5"], params["x-ms-blob-content-md5"]());
                     assert.equal(uploadRequest.requestHeaders["x-ms-blob-cache-control"], params["x-ms-blob-cache-control"]);
                     done();
                 }, 0);

--- a/test/unit/azure/simple-file-uploads.js
+++ b/test/unit/azure/simple-file-uploads.js
@@ -383,5 +383,49 @@ if (qqtest.canDownloadFileAsBlob) {
 
             });
         });
+        
+        it("test if azure specific header keys and their values remain as-is", function(done) {
+            var uploader = new qq.azure.FineUploaderBasic({
+                    request: {endpoint: testEndpoint},
+                    signature: {endpoint: testSignatureEndoint}
+                }
+            );
+            
+            var params = {
+                "foo1": "bar", 
+                
+                "Content-Encoding": "1rawvalue==" ,
+                "Content-Disposition": "2rawvalue==",
+                "Content-MD5": "3rawvalue==",
+                "Cache-Control": "4rawvalue==",
+                "x-ms-blob-content-encoding": "5rawvalue==",
+                "x-ms-blob-content-disposition": "6rawvalue==",
+                "x-ms-blob-content-md5": "7rawvalue==",
+                "x-ms-blob-cache-control": "8rawvalue=="
+            };
+            
+            uploader.setParams(params);
+
+            startTypicalTest(uploader, function(signatureRequest) {
+                signatureRequest.respond(200, null, "http://sasuri.com");
+
+                setTimeout(function() {
+                    var uploadRequest = fileTestHelper.getRequests()[1];
+                    uploadRequest.respond(201, null, "");
+
+                    assert.equal(uploadRequest.requestHeaders["x-ms-meta-foo1"], "bar");
+                    
+                    assert.equal(uploadRequest.requestHeaders["Content-Encoding"], params["Content-Encoding"]);
+                    assert.equal(uploadRequest.requestHeaders["Content-Disposition"], params["Content-Disposition"]);
+                    assert.equal(uploadRequest.requestHeaders["Content-MD5"], params["Content-MD5"]);
+                    assert.equal(uploadRequest.requestHeaders["Cache-Control"], params["Cache-Control"]);
+                    assert.equal(uploadRequest.requestHeaders["x-ms-blob-content-encoding"], params["x-ms-blob-content-encoding"]);
+                    assert.equal(uploadRequest.requestHeaders["x-ms-blob-content-disposition"], params["x-ms-blob-content-disposition"]);
+                    assert.equal(uploadRequest.requestHeaders["x-ms-blob-content-md5"], params["x-ms-blob-content-md5"]);
+                    assert.equal(uploadRequest.requestHeaders["x-ms-blob-cache-control"], params["x-ms-blob-cache-control"]);
+                    done();
+                }, 0);
+            });
+        });
     });
 }


### PR DESCRIPTION
Adds support for a predefined list of headers which are appropriate for
Azure without the x-ms-meta- prefix.

Resolves issue #1212 and is based on similar pull request #1258.
