### PR TITLE
Fix for #1479: Blobs uploaded via Azure module with uuid mode get .undefined extension if original filename has no extension

### DIFF
--- a/client/js/azure/uploader.basic.js
+++ b/client/js/azure/uploader.basic.js
@@ -100,12 +100,12 @@
                 blobNameOptionValue = this._options.blobProperties.name,
                 uuid = this.getUuid(id),
                 filename = this.getName(id),
-                fileExtension = qq.getExtension(filename);
+                fileExtension = qq.getExtension(filename),
+                blobNameToUse = uuid;
 
             if (qq.isString(blobNameOptionValue)) {
                 switch (blobNameOptionValue) {
                     case "uuid":
-                        var blobNameToUse = uuid;
                         if (fileExtension !== undefined) {
                             blobNameToUse += "." + fileExtension;
                         }

--- a/client/js/azure/uploader.basic.js
+++ b/client/js/azure/uploader.basic.js
@@ -105,7 +105,11 @@
             if (qq.isString(blobNameOptionValue)) {
                 switch (blobNameOptionValue) {
                     case "uuid":
-                        return new qq.Promise().success(uuid + "." + fileExtension);
+                        var blobNameToUse = uuid;
+                        if (fileExtension !== undefined) {
+                            blobNameToUse += "." + fileExtension;
+                        }
+                        return new qq.Promise().success(blobNameToUse);
                     case "filename":
                         return new qq.Promise().success(filename);
                     default:


### PR DESCRIPTION
Fix for #1479: Blobs with uuid mode get .undefined extension if original filename has no extension