### PR TITLE
Allow access to chunk data.

### DIFF
--- a/client/js/traditional/traditional.xhr.upload.handler.js
+++ b/client/js/traditional/traditional.xhr.upload.handler.js
@@ -21,11 +21,11 @@ qq.traditional.XhrUploadHandler = function(spec, proxy) {
             var size = getSize(id),
                 name = getName(id);
 
-            params[spec.chunking.paramNames.partIndex] = chunkData.part;
-            params[spec.chunking.paramNames.partByteOffset] = chunkData.start;
-            params[spec.chunking.paramNames.chunkSize] = chunkData.size;
-            params[spec.chunking.paramNames.totalParts] = chunkData.count;
-            params[spec.totalFileSizeName] = size;
+            params[spec.chunking.paramNames.partIndex] = params.partIndex || chunkData.part;
+            params[spec.chunking.paramNames.partByteOffset] = params.partByteOffset || chunkData.start;
+            params[spec.chunking.paramNames.chunkSize] = params.chunkSize || chunkData.size;
+            params[spec.chunking.paramNames.totalParts] = params.totalParts || chunkData.count;
+            params[spec.totalFileSizeName] = params.totalFileSize || size;
 
             /**
              * When a Blob is sent in a multipart request, the filename value in the content-disposition header is either "blob"

--- a/client/js/upload-handler/upload.handler.controller.js
+++ b/client/js/upload-handler/upload.handler.controller.js
@@ -122,10 +122,11 @@ qq.UploadHandlerController = function(o, namespace) {
             //This event was created in case someone needs to manipulate the content of the chunk.
             //It validates the chunk size afterwards so it doesn't cause any problems.
             //File integrity is the developer's responsability in case they want to manipulate the blob.
-            //The usage of this event isn't recommended unless it's REALLY necessary and the developer knows what they are doing. 
+            //The usage of this event isn't recommended unless it's REALLY necessary and the developer knows what they are doing.
             options.onProcessingChunkData(id, chunkData, function () {
-                if (chunkData.blob.size !== originalBlobSize && chunkData.count < chunkData.part)
+                if (chunkData.blob.size !== originalBlobSize && chunkData.count < chunkData.part) {
                     throw "The chunk size has changed.";
+                }
 
                 //This will update the cached chunk in case it has changed.
                 handler.updateCachedChunk(id, chunkIdx, chunkData.blob);

--- a/client/js/upload-handler/xhr.upload.handler.js
+++ b/client/js/upload-handler/xhr.upload.handler.js
@@ -259,7 +259,8 @@ qq.XhrUploadHandler = function(spec) {
                 partIndex: chunkData.part,
                 startByte: chunkData.start + 1,
                 endByte: chunkData.end,
-                totalParts: chunkData.count
+                totalParts: chunkData.count,
+                chunkSize: chunkData.size
             };
         },
 

--- a/client/js/upload-handler/xhr.upload.handler.js
+++ b/client/js/upload-handler/xhr.upload.handler.js
@@ -72,6 +72,17 @@ qq.XhrUploadHandler = function(spec) {
             delete handler._getFileState(id).temp.cachedChunks[chunkIdx];
         },
 
+        updateCachedChunk: function(id, chunkIndex, blob) {
+            var chunkSize = chunking.partSize,
+                fileSize = getSize(id),
+                fileOrBlob = handler.getFile(id),
+                startBytes = chunkSize * chunkIndex,
+                endBytes = startBytes + chunkSize >= fileSize ? fileSize : startBytes + chunkSize,
+                cachedChunks = this._getFileState(id).temp.cachedChunks;
+
+            cachedChunks[chunkIndex] = blob || qq.sliceBlob(fileOrBlob, startBytes, endBytes);
+        },
+
         clearXhr: function(id, chunkIdx) {
             var tempState = handler._getFileState(id).temp;
 

--- a/client/js/uploader.api.js
+++ b/client/js/uploader.api.js
@@ -425,6 +425,10 @@
             }
         },
 
+        _onProcessingChunkData: function(id, chunkData, processedDataCallback) {
+            this._parent.prototype._onProcessingChunkData.apply(this, arguments);
+        },
+
         _onCancel: function(id, name) {
             this._parent.prototype._onCancel.apply(this, arguments);
             this._removeFileItem(id);

--- a/client/js/uploader.basic.api.js
+++ b/client/js/uploader.basic.api.js
@@ -1514,8 +1514,9 @@
         },
 
         _onProcessingChunkData: function(id, chunkData, processedDataCallback) {
-            if (!chunkData.handled)
+            if (!chunkData.handled) {
                 processedDataCallback();
+            }
         },
 
         _onUploadStatusChange: function(id, oldStatus, newStatus) {

--- a/client/js/uploader.basic.api.js
+++ b/client/js/uploader.basic.api.js
@@ -733,6 +733,10 @@
                         self._onUploadChunk(id, chunkData);
                         self._options.callbacks.onUploadChunk(id, name, chunkData);
                     },
+                    onProcessingChunkData: function(id, chunkData, processedDataCallback) {
+                        self._options.callbacks.onProcessingChunkData.apply(self, arguments);
+                        self._onProcessingChunkData(id, chunkData, processedDataCallback);
+                    },
                     onUploadChunkSuccess: function(id, chunkData, result, xhr) {
                         self._options.callbacks.onUploadChunkSuccess.apply(self, arguments);
                     },
@@ -1507,6 +1511,11 @@
 
         _onUploadChunk: function(id, chunkData) {
             //nothing to do in the base uploader
+        },
+
+        _onProcessingChunkData: function(id, chunkData, processedDataCallback) {
+            if (!chunkData.handled)
+                processedDataCallback();
         },
 
         _onUploadStatusChange: function(id, oldStatus, newStatus) {

--- a/client/js/uploader.basic.js
+++ b/client/js/uploader.basic.js
@@ -51,6 +51,7 @@
                 onUpload: function(id, name) {},
                 onUploadChunk: function(id, name, chunkData) {},
                 onUploadChunkSuccess: function(id, chunkData, responseJSON, xhr) {},
+                onProcessingChunkData: function(id, chunkData, processedDataCallback) {},
                 onResume: function(id, fileName, chunkData) {},
                 onProgress: function(id, name, loaded, total) {},
                 onTotalProgress: function(loaded, total) {},


### PR DESCRIPTION
As an use case in my company, we need to be able to encrypt each chunk separately when uploading a file. In order to do that, we needed access to the blobs of the chunks, so we created an event to support this feature.

I believe that it's an important feature to have in the library to allow more flexibility and I've seen other people on the internet who needed to do something similar. Here's an example:

http://stackoverflow.com/questions/31051664/how-to-modify-current-chunk-data-during-upload-process-with-fineuploader

I believe that, if the developer use it the wrong way and breaks their upload flow, it's entirely their responsibility.
Of course, there's a check to see if the content size of the chunk changed (except for the last one).

I hope you accept this Pull Request and maybe even improve on this feature in the future. I'm sure it will be helpful for many people.