### PR TITLE
Microsoft Edge support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Fine Uploader](http://fineuploader.com/img/FineUploader_logo.png)](http://fineuploader.com/)
 
-Version: 5.7.0-1
+Version: 5.7.0
 
 [![Build Status](https://travis-ci.org/FineUploader/fine-uploader.png?branch=master)](https://travis-ci.org/FineUploader/fine-uploader)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Fine Uploader](http://fineuploader.com/img/FineUploader_logo.png)](http://fineuploader.com/)
 
-Version: 5.6.0
+Version: 5.7.0-1
 
 [![Build Status](https://travis-ci.org/FineUploader/fine-uploader.png?branch=master)](https://travis-ci.org/FineUploader/fine-uploader)
 

--- a/client/js/util.js
+++ b/client/js/util.js
@@ -538,6 +538,10 @@ var qq = function(element) {
         return qq.ie() && navigator.userAgent.indexOf("rv:11") !== -1;
     };
 
+    qq.edge = function() {
+        return navigator.userAgent.indexOf("Edge") >= 0;
+    };
+
     qq.safari = function() {
         return navigator.vendor !== undefined && navigator.vendor.indexOf("Apple") !== -1;
     };
@@ -551,7 +555,7 @@ var qq = function(element) {
     };
 
     qq.firefox = function() {
-        return (!qq.ie11() && navigator.userAgent.indexOf("Mozilla") !== -1 && navigator.vendor !== undefined && navigator.vendor === "");
+        return (!qq.edge() && !qq.ie11() && navigator.userAgent.indexOf("Mozilla") !== -1 && navigator.vendor !== undefined && navigator.vendor === "");
     };
 
     qq.windows = function() {

--- a/client/js/version.js
+++ b/client/js/version.js
@@ -1,2 +1,2 @@
 /*global qq */
-qq.version = "5.6.0";
+qq.version = "5.7.0-1";

--- a/client/js/version.js
+++ b/client/js/version.js
@@ -1,2 +1,2 @@
 /*global qq */
-qq.version = "5.7.0-1";
+qq.version = "5.7.0";

--- a/docs/browser-support.jmd
+++ b/docs/browser-support.jmd
@@ -6,14 +6,15 @@
 
 Currently, Fine Uploader supports the following browsers:
 
-* Internet Explorer 8+
-* Firefox
 * Chrome
-* Chrome mobile (iOS & Android)
+* Firefox
+* Microsoft Edge 13.10586+
 * Opera 15+
 * Android 2.3.x+
 * iOS 6+
 * Safari 5+ (OS X)
+* Chrome mobile (iOS & Android)
+* Internet Explorer 8+
 
 ## Feature Support Matrix
 
@@ -125,6 +126,26 @@ Note: Any features not listed here are supported in all browsers.
         </tr>
         <tr>
             <td>Firefox</td>
+            <td>{{ label('√', "success") }}</td>
+            <td>{{ label('√', "success") }}</td>
+            <td>{{ label('√', "success") }}</td>
+            <td>{{ label('x', "important") }}</td>
+            <td>{{ label('x', "important") }}</td>
+            <td>{{ label('√', "success") }}</td>
+            <td>{{ label('√', "success") }}</td>
+            <td>{{ label('x', "important") }}</td>
+            <td>{{ label('√', "success") }}</td>
+            <td>{{ label('√', "success") }}</td>
+            <td>{{ label('√', "success") }}</td>
+            <td>{{ label('√', "success") }}</td>
+            <td>{{ label('√', "success") }}</td>
+            <td>{{ label('√', "success") }}</td>
+            <td>{{ label('√', "success") }}</td>
+            <td>{{ label('√', "success") }}</td>
+            <td>{{ label('√', "success") }}</td>
+        </tr>
+        <tr>
+            <td>Edge 13.10586+</td>
             <td>{{ label('√', "success") }}</td>
             <td>{{ label('√', "success") }}</td>
             <td>{{ label('√', "success") }}</td>

--- a/docs/features/chunking.jmd
+++ b/docs/features/chunking.jmd
@@ -26,7 +26,7 @@ sizes to about 4GB) and servers (e.g. [PHP's `post_max_size`][postmaxsize]).
 the upload will be _not_ be chunked.", "default", "Amazon S3 Specific Note:") }}
 
 Chunking is made possible by the File API, and is supported in Chrome, Firefox,
-Safari (iOS 6+ and OS X), Internet Explorer 10+, and Opera 15+. Chunking is disabled in
+Safari (iOS 6+ and OS X), Internet Explorer 10+, Opera 15+, and Microsoft Edge 13.10586+. Chunking is disabled in
 Android's stock browser due to a bug in the browser's ability to upload Blobs.
 
 Each chunk is sent as a separate request, and each chunked request

--- a/docs/features/styling.jmd
+++ b/docs/features/styling.jmd
@@ -145,7 +145,7 @@ to this:
 </div>
 ```
 
-Note that you cannot use a `<button>` element if you plan on supported Internet Explorer, as this will not trigger
+Note that you cannot use a `<button>` element if you plan on supporting Internet Explorer, as this will not trigger
 the file chooser dialog.
 
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fine-uploader",
   "title": "Fine Uploader",
-  "version": "5.6.0",
+  "version": "5.7.0-1",
   "description": "Multiple file upload component with progress-bar, drag-and-drop, support for all modern browsers.",
   "main": "./fine-uploader/js/fineuploader.js",
   "directories": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fine-uploader",
   "title": "Fine Uploader",
-  "version": "5.7.0-1",
+  "version": "5.7.0",
   "description": "Multiple file upload component with progress-bar, drag-and-drop, support for all modern browsers.",
   "main": "./fine-uploader/js/fineuploader.js",
   "directories": {

--- a/test/dev/handlers/composer.json
+++ b/test/dev/handlers/composer.json
@@ -8,6 +8,6 @@
   ],
   "require": {
     "fineuploader/php-traditional-server": "1.0.1",
-    "fineuploader/php-s3-server": "dev-v4-signatures"
+    "fineuploader/php-s3-server": "1.1.0"
   }
 }

--- a/test/unit/scaling.js
+++ b/test/unit/scaling.js
@@ -404,11 +404,11 @@ if (qq.supportedFeatures.scaling) {
                             acknowledgeRequests();
                         },
                         onUpload: function(id, name) {
+                            actualUploadCallbacks.push({id: id, name: name});
+
                             assert.ok(uploader.getSize(id) > 0);
                             assert.ok(qq.isBlob(uploader.getFile(id)));
                             assert.equal(uploader.getFile(id).size, referenceFileSize);
-
-                            actualUploadCallbacks.push({id: id, name: name});
                         },
                         onAllComplete: function(successful, failed) {
                             assert.equal(successful.length, 4);


### PR DESCRIPTION
This irons out issues with file dropping in Edge and updates docs to indicate support. It is initially scheduled as the only change in 5.7.0.

Original issue for Edge support is #1422.