### PR TITLE
docs(contributing): attempt to re-integrate clahub.com

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -4,3 +4,5 @@ The issue tracker in this project is for bug reports or feature requests ONLY.  
 please see http://fineuploader.com/support.html which contains instructions on where you can browse and open support 
 requests. All pull requests and issues _must_ include all required fields in the respective template. If items
 from these fields are missing, the pull request or issue report may be closed as a result.
+
+**If this is a pull request, please sign [the Contributor License Agreement](https://www.clahub.com/agreements/FineUploader/fine-uploader).**

--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -12,33 +12,3 @@
 
 ## Is this pull request against develop or some other non-master branch? [REQUIRED]
 {Choose one: "yes" or "no". If "no", then why not?}
-
-
-## Contributor Agreement
-**If you are contributing any code whatsoever, you _must_ agree to the terms below. Please indicate your agreement by typing your name below this line.**
-
-
-In order to clarify the intellectual property license granted with Contributions from any person or entity, Widen must have a Contributor License Agreement (“CLA”) on file that has been signed by each Contributor, indicating agreement to the license terms below. This license is for your protection as a Contributor as well as the protection of Widen; it does not change your rights to use your own Contributions for any other purpose.
-
-You accept and agree to the following terms and conditions for Your present and future Contributions submitted to Widen. Except for the license granted herein to Widen and recipients of software distributed by Widen, You reserve all right, title, and interest in and to Your Contributions.
-
-1. Definitions.
-“You” (or “Your”) shall mean the copyright owner or legal entity authorized by the copyright owner that is making this Agreement with Widen. For legal entities, the entity making a Contribution and all other entities that control, are controlled by, or are under common control with that entity are considered to be a single Contributor. For the purposes of this definition, “control” means (i) the power, direct or indirect, to cause the direction or management of such entity, whether by contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the outstanding shares, or (iii) beneficial ownership of such entity.
-
-“Contribution” shall mean any original work of authorship, including any modifications or additions to an existing work, that is intentionally submitted by You to Widen for inclusion in, or documentation of, any of the products owned or managed by Widen (the “Work”). For the purposes of this definition, “submitted” means any form of electronic, verbal, or written communication sent to Widen or its representatives, including but not limited to communication on electronic mailing lists, source code control systems, and issue tracking systems that are managed by, or on behalf of, Widen for the purpose of discussing and improving the Work, but excluding communication that is conspicuously marked or otherwise designated in writing by You as “Not a Contribution.”
-
-1. Grant of Copyright License. Subject to the terms and conditions of this Agreement, You hereby grant to Widen and to recipients of software distributed by Widen a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright license to reproduce, prepare derivative works of, publicly display, publicly perform, sublicense, and distribute Your Contributions and such derivative works.
-
-2. Grant of Patent License. Subject to the terms and conditions of this Agreement, You hereby grant to Widen and to recipients of software distributed by Widen a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except as stated in this section) patent license to make, have made, use, offer to sell, sell, import, and otherwise transfer the Work, where such license applies only to those patent claims licensable by You that are necessarily infringed by Your Contribution(s) alone or by combination of Your Contribution(s) with the Work to which such Contribution(s) was submitted. If any entity institutes patent litigation against You or any other entity (including a cross-claim or counterclaim in a lawsuit) alleging that your Contribution, or the Work to which you have contributed, constitutes direct or contributory patent infringement, then any patent licenses granted to that entity under this Agreement for that Contribution or Work shall terminate as of the date such litigation is filed.
-
-3. You represent that you are legally entitled to grant the above license. If your employer(s) has rights to intellectual property that you create that includes your Contributions, you represent that you have received permission to make Contributions on behalf of that employer, that your employer has waived such rights for your Contributions to Widen, or that your employer has executed a separate Corporate CLA with Widen.
-
-4. You represent that each of Your Contributions is Your original creation (see section 7 for submissions on behalf of others). You represent that Your Contribution submissions include complete details of any third-party license or other restriction (including, but not limited to, related patents and trademarks) of which you are personally aware and which are associated with any part of Your Contributions.
-
-5. You are not expected to provide support for Your Contributions, except to the extent You desire to provide support. You may provide support for free, for a fee, or not at all. Unless required by applicable law or agreed to in writing, You provide Your Contributions on an “AS IS” BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied, including, without limitation, any warranties or conditions of TITLE, NON- INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE.
-
-6. Should You wish to submit work that is not Your original creation, You may submit it to Widen separately from any Contribution, identifying the complete details of its source and of any license or other restriction (including, but not limited to, related patents, trademarks, and license agreements) of which you are personally aware, and conspicuously marking the work as “Submitted on behalf of a third-party: [[]named here]”.
-
-7. You agree to notify Widen of any facts or circumstances of which you become aware that would make these representations inaccurate in any respect.
-
-Thank you!


### PR DESCRIPTION
This is an attempt to move CLA signing to clahub.com. This failed a year or so ago, but the project has changed now and is actively maintained. The benefit of using clahub.com is that it ensure CLA signers are maintained in a central location and are not modifiable. The previous approach which requires the contributor to sign in a PR was flawed in that the contributor could, at any time, edit their PR comment/description to revoke this agreement without any good audit trail.