### PR TITLE
CommonJS + AMD support

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -24,6 +24,7 @@ module.exports = function(grunt) {
     path = require("path");
     pkg = require("./package.json");
     paths = {
+        commonJs: "./lib/commonJs",
         dist: path.join("./_dist", pkg.version),
         build: "./_build",
         src: "./client",

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Fine Uploader](http://fineuploader.com/img/FineUploader_logo.png)](http://fineuploader.com/)
 
-Version: 5.8.0-beta1
+Version: 5.8.0
 
 [![Build Status](https://travis-ci.org/FineUploader/fine-uploader.png?branch=master)](https://travis-ci.org/FineUploader/fine-uploader)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Fine Uploader](http://fineuploader.com/img/FineUploader_logo.png)](http://fineuploader.com/)
 
-Version: 5.8.0-1
+Version: 5.8.0-beta1
 
 [![Build Status](https://travis-ci.org/FineUploader/fine-uploader.png?branch=master)](https://travis-ci.org/FineUploader/fine-uploader)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Fine Uploader](http://fineuploader.com/img/FineUploader_logo.png)](http://fineuploader.com/)
 
-Version: 5.7.1
+Version: 5.8.0
 
 [![Build Status](https://travis-ci.org/FineUploader/fine-uploader.png?branch=master)](https://travis-ci.org/FineUploader/fine-uploader)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Fine Uploader](http://fineuploader.com/img/FineUploader_logo.png)](http://fineuploader.com/)
 
-Version: 5.8.0
+Version: 5.8.0-1
 
 [![Build Status](https://travis-ci.org/FineUploader/fine-uploader.png?branch=master)](https://travis-ci.org/FineUploader/fine-uploader)
 

--- a/client/js/image-support/scaler.js
+++ b/client/js/image-support/scaler.js
@@ -342,7 +342,7 @@ qq.extend(qq.Scaler.prototype, {
 
         reader.onload = function() {
             originalImageDataUri = reader.result;
-            insertionEffort.success(ExifRestorer.restore(originalImageDataUri, scaledImageDataUri));
+            insertionEffort.success(qq.ExifRestorer.restore(originalImageDataUri, scaledImageDataUri));
         };
 
         reader.onerror = function() {

--- a/client/js/s3/request-signer.js
+++ b/client/js/s3/request-signer.js
@@ -77,19 +77,19 @@ qq.s3.RequestSigner = function(o) {
             },
 
             signApiRequest: function(signatureConstructor, headersStr, signatureEffort) {
-                var headersWordArray = CryptoJS.enc.Utf8.parse(headersStr),
-                    headersHmacSha1 = CryptoJS.HmacSHA1(headersWordArray, credentialsProvider.get().secretKey),
-                    headersHmacSha1Base64 = CryptoJS.enc.Base64.stringify(headersHmacSha1);
+                var headersWordArray = qq.CryptoJS.enc.Utf8.parse(headersStr),
+                    headersHmacSha1 = qq.CryptoJS.HmacSHA1(headersWordArray, credentialsProvider.get().secretKey),
+                    headersHmacSha1Base64 = qq.CryptoJS.enc.Base64.stringify(headersHmacSha1);
 
                 generateHeaders(signatureConstructor, headersHmacSha1Base64, signatureEffort);
             },
 
             signPolicy: function(policy, signatureEffort, updatedAccessKey, updatedSessionToken) {
                 var policyStr = JSON.stringify(policy),
-                    policyWordArray = CryptoJS.enc.Utf8.parse(policyStr),
-                    base64Policy = CryptoJS.enc.Base64.stringify(policyWordArray),
-                    policyHmacSha1 = CryptoJS.HmacSHA1(base64Policy, credentialsProvider.get().secretKey),
-                    policyHmacSha1Base64 = CryptoJS.enc.Base64.stringify(policyHmacSha1);
+                    policyWordArray = qq.CryptoJS.enc.Utf8.parse(policyStr),
+                    base64Policy = qq.CryptoJS.enc.Base64.stringify(policyWordArray),
+                    policyHmacSha1 = qq.CryptoJS.HmacSHA1(base64Policy, credentialsProvider.get().secretKey),
+                    policyHmacSha1Base64 = qq.CryptoJS.enc.Base64.stringify(policyHmacSha1);
 
                 signatureEffort.success({
                     policy: base64Policy,
@@ -164,8 +164,8 @@ qq.s3.RequestSigner = function(o) {
                                 promise.failure(e.target.error);
                             }
                             else {
-                                var wordArray = CryptoJS.lib.WordArray.create(e.target.result);
-                                promise.success(CryptoJS.SHA256(wordArray).toString());
+                                var wordArray = qq.CryptoJS.lib.WordArray.create(e.target.result);
+                                promise.success(qq.CryptoJS.SHA256(wordArray).toString());
                             }
                         }
                     };
@@ -173,7 +173,7 @@ qq.s3.RequestSigner = function(o) {
                 }
                 else {
                     body = body || "";
-                    promise.success(CryptoJS.SHA256(body).toString());
+                    promise.success(qq.CryptoJS.SHA256(body).toString());
                 }
 
                 return promise;
@@ -187,7 +187,7 @@ qq.s3.RequestSigner = function(o) {
             getStringToSign: function(signatureSpec) {
                 var canonicalRequest = v4.getCanonicalRequest(signatureSpec),
                     date = qq.s3.util.getV4PolicyDate(signatureSpec.date, signatureSpec.drift),
-                    hashedRequest = CryptoJS.SHA256(canonicalRequest).toString(),
+                    hashedRequest = qq.CryptoJS.SHA256(canonicalRequest).toString(),
                     scope = v4.getScope(signatureSpec.date, options.signatureSpec.region),
                     stringToSignTemplate = "AWS4-HMAC-SHA256\n{}\n{}\n{}";
 
@@ -217,18 +217,18 @@ qq.s3.RequestSigner = function(o) {
                     matches = headersPattern.exec(headersStr),
                     dateKey, dateRegionKey, dateRegionServiceKey, signingKey;
 
-                dateKey = CryptoJS.HmacSHA256(matches[1], "AWS4" + secretKey);
-                dateRegionKey = CryptoJS.HmacSHA256(matches[2], dateKey);
-                dateRegionServiceKey = CryptoJS.HmacSHA256("s3", dateRegionKey);
-                signingKey = CryptoJS.HmacSHA256("aws4_request", dateRegionServiceKey);
+                dateKey = qq.CryptoJS.HmacSHA256(matches[1], "AWS4" + secretKey);
+                dateRegionKey = qq.CryptoJS.HmacSHA256(matches[2], dateKey);
+                dateRegionServiceKey = qq.CryptoJS.HmacSHA256("s3", dateRegionKey);
+                signingKey = qq.CryptoJS.HmacSHA256("aws4_request", dateRegionServiceKey);
 
-                generateHeaders(signatureConstructor, CryptoJS.HmacSHA256(headersStr, signingKey), signatureEffort);
+                generateHeaders(signatureConstructor, qq.CryptoJS.HmacSHA256(headersStr, signingKey), signatureEffort);
             },
 
             signPolicy: function(policy, signatureEffort, updatedAccessKey, updatedSessionToken) {
                 var policyStr = JSON.stringify(policy),
-                    policyWordArray = CryptoJS.enc.Utf8.parse(policyStr),
-                    base64Policy = CryptoJS.enc.Base64.stringify(policyWordArray),
+                    policyWordArray = qq.CryptoJS.enc.Utf8.parse(policyStr),
+                    base64Policy = qq.CryptoJS.enc.Base64.stringify(policyWordArray),
                     secretKey = credentialsProvider.get().secretKey,
                     credentialPattern = /.+\/(.+)\/(.+)\/s3\/aws4_request/,
                     credentialCondition = (function() {
@@ -245,14 +245,14 @@ qq.s3.RequestSigner = function(o) {
                     matches, dateKey, dateRegionKey, dateRegionServiceKey, signingKey;
 
                 matches = credentialPattern.exec(credentialCondition);
-                dateKey = CryptoJS.HmacSHA256(matches[1], "AWS4" + secretKey);
-                dateRegionKey = CryptoJS.HmacSHA256(matches[2], dateKey);
-                dateRegionServiceKey = CryptoJS.HmacSHA256("s3", dateRegionKey);
-                signingKey = CryptoJS.HmacSHA256("aws4_request", dateRegionServiceKey);
+                dateKey = qq.CryptoJS.HmacSHA256(matches[1], "AWS4" + secretKey);
+                dateRegionKey = qq.CryptoJS.HmacSHA256(matches[2], dateKey);
+                dateRegionServiceKey = qq.CryptoJS.HmacSHA256("s3", dateRegionKey);
+                signingKey = qq.CryptoJS.HmacSHA256("aws4_request", dateRegionServiceKey);
 
                 signatureEffort.success({
                     policy: base64Policy,
-                    signature: CryptoJS.HmacSHA256(base64Policy, signingKey).toString()
+                    signature: qq.CryptoJS.HmacSHA256(base64Policy, signingKey).toString()
                 }, updatedAccessKey, updatedSessionToken);
             }
         };
@@ -487,7 +487,7 @@ qq.s3.RequestSigner = function(o) {
                 queryParams = {v4: true};
             }
 
-            if (credentialsProvider.get().secretKey && window.CryptoJS) {
+            if (credentialsProvider.get().secretKey && qq.CryptoJS) {
                 if (credentialsProvider.get().expiration.getTime() > Date.now()) {
                     determineSignatureClientSide(id, toBeSigned, signatureEffort);
                 }

--- a/client/js/third-party/ExifRestorer.js
+++ b/client/js/third-party/ExifRestorer.js
@@ -1,7 +1,7 @@
 //Based on MinifyJpeg
 //http://elicon.blog57.fc2.com/blog-entry-206.html
 
-var ExifRestorer = (function()
+qq.ExifRestorer = (function()
 {
    
 	var ExifRestorer = {};

--- a/client/js/third-party/crypto-js/core.js
+++ b/client/js/third-party/crypto-js/core.js
@@ -7,7 +7,7 @@ code.google.com/p/crypto-js/wiki/License
 /**
  * CryptoJS core components.
  */
-var CryptoJS = CryptoJS || (function (Math, undefined) {
+qq.CryptoJS = (function (Math, undefined) {
     /**
      * CryptoJS namespace.
      */

--- a/client/js/third-party/crypto-js/enc-base64.js
+++ b/client/js/third-party/crypto-js/enc-base64.js
@@ -6,7 +6,7 @@ code.google.com/p/crypto-js/wiki/License
 */
 (function () {
     // Shortcuts
-    var C = CryptoJS;
+    var C = qq.CryptoJS;
     var C_lib = C.lib;
     var WordArray = C_lib.WordArray;
     var C_enc = C.enc;

--- a/client/js/third-party/crypto-js/hmac.js
+++ b/client/js/third-party/crypto-js/hmac.js
@@ -6,7 +6,7 @@ code.google.com/p/crypto-js/wiki/License
 */
 (function () {
     // Shortcuts
-    var C = CryptoJS;
+    var C = qq.CryptoJS;
     var C_lib = C.lib;
     var Base = C_lib.Base;
     var C_enc = C.enc;

--- a/client/js/third-party/crypto-js/lib-typedarrays.js
+++ b/client/js/third-party/crypto-js/lib-typedarrays.js
@@ -11,7 +11,7 @@ code.google.com/p/crypto-js/wiki/License
     }
 
     // Shortcuts
-    var C = CryptoJS;
+    var C = qq.CryptoJS;
     var C_lib = C.lib;
     var WordArray = C_lib.WordArray;
 

--- a/client/js/third-party/crypto-js/sha1.js
+++ b/client/js/third-party/crypto-js/sha1.js
@@ -6,7 +6,7 @@ code.google.com/p/crypto-js/wiki/License
 */
 (function () {
     // Shortcuts
-    var C = CryptoJS;
+    var C = qq.CryptoJS;
     var C_lib = C.lib;
     var WordArray = C_lib.WordArray;
     var Hasher = C_lib.Hasher;

--- a/client/js/third-party/crypto-js/sha256.js
+++ b/client/js/third-party/crypto-js/sha256.js
@@ -6,7 +6,7 @@ code.google.com/p/crypto-js/wiki/License
 */
 (function (Math) {
     // Shortcuts
-    var C = CryptoJS;
+    var C = qq.CryptoJS;
     var C_lib = C.lib;
     var WordArray = C_lib.WordArray;
     var Hasher = C_lib.Hasher;

--- a/client/js/version.js
+++ b/client/js/version.js
@@ -1,2 +1,2 @@
 /*global qq */
-qq.version = "5.8.0-1";
+qq.version = "5.8.0-beta1";

--- a/client/js/version.js
+++ b/client/js/version.js
@@ -1,2 +1,2 @@
 /*global qq */
-qq.version = "5.8.0";
+qq.version = "5.8.0-1";

--- a/client/js/version.js
+++ b/client/js/version.js
@@ -1,2 +1,2 @@
 /*global qq */
-qq.version = "5.7.1";
+qq.version = "5.8.0";

--- a/client/js/version.js
+++ b/client/js/version.js
@@ -1,2 +1,2 @@
 /*global qq */
-qq.version = "5.8.0-beta1";
+qq.version = "5.8.0";

--- a/docs/features/forms.jmd
+++ b/docs/features/forms.jmd
@@ -79,6 +79,11 @@ The form support feature, like most other Fine Uploader features, works in all s
 The simplest use-case results in a very simple example, with only one line of JavaScript!  Here is a complete HTML
 file that integrates Fine Uploader into an existing form:
 
+{{ alert(
+"""There are many ways to load Fine Uploader into your project. The code below creates a global `qq` variable, but there are
+other, better options. Please see [modules feature page](modules.html) for more details.""") }}
+
+
 ```html
 <html>
     <head>

--- a/docs/features/modules.jmd
+++ b/docs/features/modules.jmd
@@ -1,0 +1,248 @@
+{% extends "_templates/base.html" %}
+{% set page_title = "Importing Fine Uploader" %}
+{% block content %}
+{% markdown %}
+
+# Importing Fine Uploader {: .page-header }
+
+You have the following options when pulling Fine Uploader into your project:
+
+1. CommonJS (`require`).
+2. ES6 Modules (`import`).
+3. Globally scoped (`<script src="...">`)
+
+The first two options assume you are downloading [Fine Uploader via npm][npm]. However, all three options are available
+should you choose the download the library with npm. The _preferred_ way to download Fine Uploader is in fact through npm.
+
+A new "lib" directory is available in the npm package. Among the JavaScript and placeholder image files, the three CSS files
+are available as well, but with different names. The legacy css file is named "legacy.css". Generally speaking, you should
+avoid using this stylesheet unless you have old code that depends on these styles. The "fine-uploader-new.css" stylsheet that contains
+a more modern set of styles for a row-based uploader has been appropriately named "rows.css". Finally, the "fine-uploader-gallery.css"
+stylesheet which supports a gallery view of submitted files is named "gallery.css". For more information about styling
+your uploader, please see [the styling feature page](styling.html).
+
+The following sections cover, in detail, the three options you have for importing Fine Uploader, once you have downloaded
+the library. They are ordered by preference.
+
+
+## ES6 Modules
+
+At the writing of this feature page, the JavaScript modules specification is completed and part of the ECMAScript-262
+6th edition standard. However, at this time, no browser implements this specification. But there are still many options
+available to you should you choose to make use of ES6 modules when loading Fine Uploader into your project.
+Without native browser support, you must make use of a tool that compiles ES6 module syntax into a format that is
+parsable by all browsers. There are many such tools, but the more popular options are:
+
+- [Babel][babel] + [Webpack][webpack] v1
+- [Webpack][webpack] v2+
+- [Rollup][rollup]
+- [TypeScript][typescript]
+
+Importing your desired Fine Uploader resources is as simple as using `import` statements. For example:
+
+```javascript
+// use Fine Uploader core (non-ui) for traditional endpoints
+import qq from 'fine-uploader'
+
+const uploader = new qq.FineUploaderBasic({...})
+```
+
+```javascript
+// use Fine Uploader UI for traditional endpoints
+import qq from 'fine-uploader'
+
+// You may replace "rows" w/ "legacy" or "gallery" depending on your needs
+// This assumes you have a loader to handle importing css files, such as Webpack css-loader
+import 'fine-uploader/lib/rows.css'
+
+const uploader = new qq.FineUploader({...})
+```
+
+```javascript
+// use Fine Uploader S3
+import qq from 'fine-uploader/lib/s3'
+
+// You may replace "rows" w/ "legacy" or "gallery" depending on your needs
+// This assumes you have a loader to handle importing css files, such as Webpack css-loader
+import 'fine-uploader/lib/rows.css'
+
+const uploader = new qq.s3.FineUploader({...})
+```
+
+```javascript
+// use Fine Uploader Azure
+import qq from 'fine-uploader/lib/azure'
+
+// You may replace "rows" w/ "legacy" or "gallery" depending on your needs
+// This assumes you have a loader to handle importing css files, such as Webpack css-loader
+import 'fine-uploader/lib/rows.css'
+
+const uploader = new qq.azure.FineUploader({...})
+```
+
+```javascript
+// allow use of Fine Uploader S3, Azure, and/or traditional endpoint code
+import qq from 'fine-uploader/lib/all'
+
+// You may replace "rows" w/ "legacy" or "gallery" depending on your needs
+// This assumes you have a loader to handle importing css files, such as Webpack css-loader
+import 'fine-uploader/lib/rows.css'
+
+const traditionalUploader = new qq.FineUploader({...})
+const s3Uploader = new qq.s3.FineUploader({...})
+const azureUploader = new qq.azure.FineUploader({...})
+```
+
+
+## CommonJS
+
+If you would like to use [RequireJS][requirejs] or [Babel][babel] + [Webpack] v1, or even [Bublé][buble], you will want
+to import Fine Uploader using the `require` function. Importing your desired Fine Uploader resources is as simple
+as using `require` statements. For example:
+
+```javascript
+// use Fine Uploader core (non-ui) for traditional endpoints
+var qq = require('fine-uploader')
+
+var uploader = new qq.FineUploaderBasic({...})
+```
+
+```javascript
+// use Fine Uploader UI for traditional endpoints
+var qq = require('fine-uploader'_
+
+// You may replace "rows" w/ "legacy" or "gallery" depending on your needs
+// This assumes you have a loader to handle importing css files, such as Webpack css-loader
+require('fine-uploader/lib/rows.css')
+
+var uploader = new qq.FineUploader({...})
+```
+
+```javascript
+// use Fine Uploader S3
+var qq = require('fine-uploader/lib/s3')
+
+// You may replace "rows" w/ "legacy" or "gallery" depending on your needs
+// This assumes you have a loader to handle importing css files, such as Webpack css-loader
+require('fine-uploader/lib/rows.css')
+
+var uploader = new qq.s3.FineUploader({...})
+```
+
+```javascript
+// use Fine Uploader Azure
+var qq = require('fine-uploader/lib/azure')
+
+// You may replace "rows" w/ "legacy" or "gallery" depending on your needs
+// This assumes you have a loader to handle importing css files, such as Webpack css-loader
+require('fine-uploader/lib/rows.css')
+
+var uploader = new qq.azure.FineUploader({...})
+```
+
+```javascript
+// allow use of Fine Uploader S3, Azure, and/or traditional endpoint code
+var qq = require('fine-uploader/lib/all')
+
+// You may replace "rows" w/ "legacy" or "gallery" depending on your needs
+// This assumes you have a loader to handle importing css files, such as Webpack css-loader
+require('fine-uploader/lib/rows.css')
+
+var traditionalUploader = new qq.FineUploader({...})
+var s3Uploader = new qq.s3.FineUploader({...})
+var azureUploader = new qq.azure.FineUploader({...})
+```
+
+
+## Globally Scoped
+
+The traditional way to pull Fine Uploader onto a page is to do so using `<script>` and `<link>` tags. Before version
+5.8.0, this was the _only_ way to properly import Fine Uploader. The downside of this approach is that you are left with
+a global variable attached to `window` - `qq`. Importing Fine Uploader as a globally scoped object can be accomplished
+as follows:
+
+```html
+<!-- use Fine Uploader core (non-ui) for traditional endpoints -->
+<script src="node_modules/fine-uploader/fine-uploader.js" type="text/javascript"></script>
+
+<script>
+    (function() {
+        var uploader = new qq.FineUploaderBasic({...})
+    }())
+</script>
+```
+
+```html
+<!-- use Fine Uploader UI for traditional endpoints -->
+<script src="node_modules/fine-uploader/fine-uploader.js" type="text/javascript"></script>
+
+<link href="node_modules/fine-uploader/fine-uploader-new.css" rel="stylesheet" type="text/css"/>
+
+<script>
+    (function() {
+        var uploader = new qq.FineUploader({...})
+    }())
+</script>
+```
+
+```javascript
+<!-- use Fine Uploader S3 -->
+<script src="node_modules/s3.fine-uploader/fine-uploader.js" type="text/javascript"></script>
+
+<link href="node_modules/s3.fine-uploader/fine-uploader-new.css" rel="stylesheet" type="text/css"/>
+
+<script>
+    (function() {
+        var uploader = new qq.s3.FineUploader({...})
+    }())
+</script>
+```
+
+```javascript
+<!-- use Fine Uploader Azure -->
+<script src="node_modules/azure.fine-uploader/fine-uploader.js" type="text/javascript"></script>
+
+<link href="node_modules/azure.fine-uploader/fine-uploader-new.css" rel="stylesheet" type="text/css"/>
+
+<script>
+    (function() {
+        var uploader = new qq.azure.FineUploader({...})
+    }())
+</script>
+```
+
+```javascript
+<!-- use Fine Uploader S3, Azure, or traditional -->
+<script src="node_modules/all.fine-uploader/fine-uploader.js" type="text/javascript"></script>
+
+<link href="node_modules/all.fine-uploader/fine-uploader-new.css" rel="stylesheet" type="text/css"/>
+
+<script>
+    (function() {
+        var traditionalUploader = new qq.FineUploader({...})
+        var s3Uploader = new qq.s3.FineUploader({...})
+        var azureUploader = new qq.azure.FineUploader({...})
+    }())
+</script>
+```
+
+
+## AMD
+
+Support for loading Fine Uploader via the Asynchronous Module Definition API is technically possible, and the code
+_should_ be in place to support this, but it is not _officially_ supported at this time. Demand for this type of loading
+is small, and we don't have a use for this in any of our projects. If you do find any issues with AMD support, please
+file an issue. We would also love to have this section of the documentation expanded to cover AMD support.
+
+
+
+[babel]: https://babeljs.io/
+[buble]: https://gitlab.com/Rich-Harris/buble
+[npm]: https://www.npmjs.com/package/fine-uploader
+[requirejs]: http://requirejs.org/
+[rollup]: http://rollupjs.org/
+[typescript]: https://www.typescriptlang.org/
+[webpack]: http://webpack.github.io/
+
+{% endmarkdown %}
+{% endblock %}

--- a/docs/features/styling.jmd
+++ b/docs/features/styling.jmd
@@ -11,6 +11,12 @@
 """Templating changed drastically in version 4.0.  If you are upgrading from a 3.x version to a 4.x version
 you will want to read the [upgrading to 4.x document](../upgrading-to-4.html) as well.""", "warn") }}
 
+{{ alert(
+"""If you are making use of ES6 modules, CommonJS, or AMD to import Fine Uploader into your project, please see
+the [modules feature page](modules.html) for information on the name changes to the stylesheets in the distributed
+lib directory.""") }}
+
+
 This document applies to Fine Uploader UI mode only, and aims to help you customize the default UI using
 the built-in templating feature.
 

--- a/docs/quickstart/01-getting-started.jmd
+++ b/docs/quickstart/01-getting-started.jmd
@@ -100,6 +100,18 @@ var uploader = new qq.FineUploader({
 });
 ```
 
+### 3. Determine how you would like to import Fine Uploader
+
+You have the following options available to pull Fine Uploader into your project:
+
+1. CommonJS (`require`).
+2. ES6 Modules (`import`).
+3. Globally scoped (`<script src="...">`)
+
+For more information on how you can load Fine Uploader into your project, please see the
+[modules feature page](../features/modules.html).
+
+
 Next, let's check out some of Fine Uploader's options.
 
 Proceed by selecting either:

--- a/docs/quickstart/02-setting_options-azure.jmd
+++ b/docs/quickstart/02-setting_options-azure.jmd
@@ -105,6 +105,10 @@ More information on [deleting files here](../features/delete.html).
 
 Now our Fine Uploader page should look something like this:
 
+{{ alert(
+"""There are many ways to load Fine Uploader into your project. The code below creates a global `qq` variable, but there are
+other, better options. Please see [modules feature page](../features/modules.html) for more details.""") }}
+
 ```html
 <html>
   <head>

--- a/docs/quickstart/02-setting_options-s3.jmd
+++ b/docs/quickstart/02-setting_options-s3.jmd
@@ -107,6 +107,10 @@ More information on [deleting files here](../features/delete.html).
 
 Now our Fine Uploader page should look something like this:
 
+{{ alert(
+"""There are many ways to load Fine Uploader into your project. The code below creates a global `qq` variable, but there are
+other, better options. Please see [modules feature page](../features/modules.html) for more details.""") }}
+
 ```html
 <html>
   <head>

--- a/docs/quickstart/02-setting_options.jmd
+++ b/docs/quickstart/02-setting_options.jmd
@@ -99,6 +99,10 @@ More information on [deleting files here](../features/delete.html).
 
 Now our Fine Uploader page should look something like this:
 
+{{ alert(
+"""There are many ways to load Fine Uploader into your project. The code below creates a global `qq` variable, but there are
+other, better options. Please see [modules feature page](../features/modules.html) for more details.""") }}
+
 ```html
 <html>
   <head>

--- a/lib/commonJs/all.js
+++ b/lib/commonJs/all.js
@@ -1,0 +1,3 @@
+"use strict";
+
+module.exports = require("../all.fine-uploader/all.fine-uploader");

--- a/lib/commonJs/azure.js
+++ b/lib/commonJs/azure.js
@@ -1,0 +1,3 @@
+"use strict";
+
+module.exports = require("../azure.fine-uploader/azure.fine-uploader");

--- a/lib/commonJs/jquery/azure.js
+++ b/lib/commonJs/jquery/azure.js
@@ -1,0 +1,3 @@
+"use strict";
+
+module.exports = require("../../azure.jquery.fine-uploader/azure.jquery.fine-uploader");

--- a/lib/commonJs/jquery/s3.js
+++ b/lib/commonJs/jquery/s3.js
@@ -1,0 +1,3 @@
+"use strict";
+
+module.exports = require("../../s3.jquery.fine-uploader/s3.jquery.fine-uploader");

--- a/lib/commonJs/jquery/traditional.js
+++ b/lib/commonJs/jquery/traditional.js
@@ -1,0 +1,3 @@
+"use strict";
+
+module.exports = require("../../jquery.fine-uploader/jquery.fine-uploader");

--- a/lib/commonJs/s3.js
+++ b/lib/commonJs/s3.js
@@ -1,0 +1,3 @@
+"use strict";
+
+module.exports = require("../s3.fine-uploader/s3.fine-uploader");

--- a/lib/commonJs/traditional.js
+++ b/lib/commonJs/traditional.js
@@ -1,0 +1,3 @@
+"use strict";
+
+module.exports = require("../fine-uploader/fine-uploader");

--- a/lib/grunt/configs/concat.js
+++ b/lib/grunt/configs/concat.js
@@ -5,51 +5,63 @@ var path = require("path"),
 module.exports = function(paths) {
     "use strict";
 
+    var jsBanner = (
+        "(function(global) {\n"
+    )
+
+    var jsFooter = (
+        "if (typeof define === 'function' && define.amd) {\n" +
+        "   define(function() {\n" +
+        "       return qq;\n" +
+        "   });\n" +
+        "}\n" +
+        "else if (typeof module !== 'undefined' && module.exports) {\n" +
+        "   module.exports = qq;\n" +
+        "}\n" +
+        "else {\n" +
+        "   global.qq = qq;\n" +
+        "}\n" +
+        "}(window));\n"
+    )
+
+    var jsOptions = {
+        banner: jsBanner,
+        footer: jsFooter
+    }
+
     return {
-        options: {
-            banner: (
-                "(function(global) {\n"
-            ),
-            footer: (
-                "if (typeof define === 'function' && define.amd) {\n" +
-                "   define(function() {\n" +
-                "       return qq;\n" +
-                "   });\n" +
-                "}\n" +
-                "else if (typeof module !== 'undefined' && module.exports) {\n" +
-                "   module.exports = qq;\n" +
-                "}\n" +
-                "else {\n" +
-                "   global.qq = qq;\n" +
-                "}\n" +
-                "}(window));\n"
-            )
-        },
         core: {
+            options: jsOptions,
             src: fineUploaderModules.mergeModules(true, "fuTraditional"),
             dest: "" + paths.build + "/<%= pkg.name %>.js"
         },
         coreS3: {
+            options: jsOptions,
             src: fineUploaderModules.mergeModules(true, "fuS3"),
             dest: "" + paths.build + "/s3.<%= pkg.name %>.js"
         },
         coreAzure: {
+            options: jsOptions,
             src: fineUploaderModules.mergeModules(true, "fuAzure"),
             dest: "" + paths.build + "/azure.<%= pkg.name %>.js"
         },
         jquery: {
+            options: jsOptions,
             src: fineUploaderModules.mergeModules(true, "fuTraditionalJquery"),
             dest: "" + paths.build + "/jquery.<%= pkg.name %>.js"
         },
         jqueryS3: {
+            options: jsOptions,
             src: fineUploaderModules.mergeModules(true, "fuS3Jquery"),
             dest: "" + paths.build + "/s3.jquery.<%= pkg.name %>.js"
         },
         jqueryAzure: {
+            options: jsOptions,
             src: fineUploaderModules.mergeModules(true, "fuAzureJquery"),
             dest: "" + paths.build + "/azure.jquery.<%= pkg.name %>.js"
         },
         all: {
+            options: jsOptions,
             src: fineUploaderModules.mergeModules(true, "fuAll"),
             dest: paths.build + "/all.<%= pkg.name %>.js"
         },

--- a/lib/grunt/configs/concat.js
+++ b/lib/grunt/configs/concat.js
@@ -6,28 +6,28 @@ module.exports = function(paths) {
     "use strict";
 
     var jsBanner = (
-        "(function(global) {\n"
-    )
+            "(function(global) {\n"
+        ),
 
-    var jsFooter = (
-        "if (typeof define === 'function' && define.amd) {\n" +
-        "   define(function() {\n" +
-        "       return qq;\n" +
-        "   });\n" +
-        "}\n" +
-        "else if (typeof module !== 'undefined' && module.exports) {\n" +
-        "   module.exports = qq;\n" +
-        "}\n" +
-        "else {\n" +
-        "   global.qq = qq;\n" +
-        "}\n" +
-        "}(window));\n"
-    )
+        jsFooter = (
+            "if (typeof define === 'function' && define.amd) {\n" +
+            "   define(function() {\n" +
+            "       return qq;\n" +
+            "   });\n" +
+            "}\n" +
+            "else if (typeof module !== 'undefined' && module.exports) {\n" +
+            "   module.exports = qq;\n" +
+            "}\n" +
+            "else {\n" +
+            "   global.qq = qq;\n" +
+            "}\n" +
+            "}(window));\n"
+        ),
 
-    var jsOptions = {
-        banner: jsBanner,
-        footer: jsFooter
-    }
+        jsOptions = {
+            banner: jsBanner,
+            footer: jsFooter
+        }
 
     return {
         core: {

--- a/lib/grunt/configs/concat.js
+++ b/lib/grunt/configs/concat.js
@@ -6,6 +6,22 @@ module.exports = function(paths) {
     "use strict";
 
     return {
+        options: {
+            banner: "(function(global) {\n",
+            footer:
+                "if (typeof define === 'function' && define.amd) {\n" +
+                "   define(function() {\n" +
+                "       return qq;\n" +
+                "   });\n" +
+                "}\n" + 
+                "else if (typeof module !== 'undefined' && module.exports) {\n" +
+                "   module.exports = qq;\n" +
+                "}\n" +
+                "else {\n" +
+                "   global.qq = qq;\n" +
+                "}\n" +
+                "}(window));\n"
+        },
         core: {
             src: fineUploaderModules.mergeModules(true, "fuTraditional"),
             dest: "" + paths.build + "/<%= pkg.name %>.js"

--- a/lib/grunt/configs/concat.js
+++ b/lib/grunt/configs/concat.js
@@ -7,8 +7,10 @@ module.exports = function(paths) {
 
     return {
         options: {
-            banner: "(function(global) {\n",
-            footer:
+            banner: (
+                "(function(global) {\n"
+            ),
+            footer: (
                 "if (typeof define === 'function' && define.amd) {\n" +
                 "   define(function() {\n" +
                 "       return qq;\n" +
@@ -21,6 +23,7 @@ module.exports = function(paths) {
                 "   global.qq = qq;\n" +
                 "}\n" +
                 "}(window));\n"
+            )
         },
         core: {
             src: fineUploaderModules.mergeModules(true, "fuTraditional"),

--- a/lib/grunt/configs/concat.js
+++ b/lib/grunt/configs/concat.js
@@ -13,7 +13,7 @@ module.exports = function(paths) {
                 "   define(function() {\n" +
                 "       return qq;\n" +
                 "   });\n" +
-                "}\n" + 
+                "}\n" +
                 "else if (typeof module !== 'undefined' && module.exports) {\n" +
                 "   module.exports = qq;\n" +
                 "}\n" +

--- a/lib/grunt/tasks/release.js
+++ b/lib/grunt/tasks/release.js
@@ -23,7 +23,7 @@ var path = require("path"),
         // remove redundancies in css filenames
         fs.renameSync(path.join(paths.dist, "lib/fine-uploader.css"), path.join(paths.dist, "lib/legacy.css"))
         fs.renameSync(path.join(paths.dist, "lib/fine-uploader-gallery.css"), path.join(paths.dist, "lib/gallery.css"))
-        fs.renameSync(path.join(paths.dist, "lib/fine-uploader-new.css"), path.join(paths.dist, "lib/new.css"))
+        fs.renameSync(path.join(paths.dist, "lib/fine-uploader-new.css"), path.join(paths.dist, "lib/rows.css"))
 
         // copy over the CommonJS index files
         fsSync.copy(path.join(paths.commonJs), path.join(paths.dist, "lib"));

--- a/lib/grunt/tasks/release.js
+++ b/lib/grunt/tasks/release.js
@@ -48,10 +48,10 @@ module.exports = function(grunt) {
             license = fs.readFileSync("LICENSE"),
             npmIgnore = "*.zip";
 
-        ["devDependencies", "scripts", "directories", "main"].forEach(function(k) {
+        ["devDependencies", "scripts", "directories"].forEach(function(k) {
             delete pkgJsonCopy[k];
         });
-
+        
         fs.writeFileSync(path.join(paths.dist, "package.json"), JSON.stringify(pkgJsonCopy, null, 2));
         fs.writeFileSync(path.join(paths.dist, ".npmignore"), npmIgnore);
         fs.writeFileSync(path.join(paths.dist, "README.md"), readme);

--- a/lib/grunt/tasks/release.js
+++ b/lib/grunt/tasks/release.js
@@ -1,7 +1,33 @@
 /* jshint node: true */
 var path = require("path"),
     npm = require("npm"),
-    fs = require("fs");
+    fs = require("fs"),
+    fsSync = require("fs-sync"),
+
+    makeCommonJsLibDir = function(paths) {
+        // copy all files from all.fine-uploader dir into lib
+        fsSync.copy(path.join(paths.dist, "all.fine-uploader"), path.join(paths.dist, "lib"));
+
+        // delete all the JS files & .min.css files
+        var libFiles = fs.readdirSync(path.join(paths.dist, "lib")),
+            index
+        for (index in libFiles) {
+            if (path.extname(libFiles[index]) === ".js") {
+                fsSync.remove(path.join(paths.dist, "lib", libFiles[index]));
+            }
+            else if (libFiles[index].endsWith(".min.css")) {
+                fsSync.remove(path.join(paths.dist, "lib", libFiles[index]));
+            }
+        }
+
+        // remove redundancies in css filenames
+        fs.renameSync(path.join(paths.dist, "lib/fine-uploader.css"), path.join(paths.dist, "lib/legacy.css"))
+        fs.renameSync(path.join(paths.dist, "lib/fine-uploader-gallery.css"), path.join(paths.dist, "lib/gallery.css"))
+        fs.renameSync(path.join(paths.dist, "lib/fine-uploader-new.css"), path.join(paths.dist, "lib/new.css"))
+
+        // copy over the CommonJS index files
+        fsSync.copy(path.join(paths.commonJs), path.join(paths.dist, "lib"));
+    }
 
 module.exports = function(grunt) {
     "use strict";
@@ -51,6 +77,8 @@ module.exports = function(grunt) {
         ["devDependencies", "scripts", "directories"].forEach(function(k) {
             delete pkgJsonCopy[k];
         });
+
+        makeCommonJsLibDir(paths);
 
         fs.writeFileSync(path.join(paths.dist, "package.json"), JSON.stringify(pkgJsonCopy, null, 2));
         fs.writeFileSync(path.join(paths.dist, ".npmignore"), npmIgnore);

--- a/lib/grunt/tasks/release.js
+++ b/lib/grunt/tasks/release.js
@@ -51,7 +51,7 @@ module.exports = function(grunt) {
         ["devDependencies", "scripts", "directories"].forEach(function(k) {
             delete pkgJsonCopy[k];
         });
-        
+
         fs.writeFileSync(path.join(paths.dist, "package.json"), JSON.stringify(pkgJsonCopy, null, 2));
         fs.writeFileSync(path.join(paths.dist, ".npmignore"), npmIgnore);
         fs.writeFileSync(path.join(paths.dist, "README.md"), readme);

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fine-uploader",
   "title": "Fine Uploader",
-  "version": "5.7.1",
+  "version": "5.8.0",
   "description": "Multiple file upload component with progress-bar, drag-and-drop, support for all modern browsers.",
   "main": "./fine-uploader/js/fineuploader.js",
   "directories": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "fine-uploader",
   "title": "Fine Uploader",
   "main": "lib/traditional.js",
-  "version": "5.8.0",
+  "version": "5.8.0-1",
   "description": "Multiple file upload component with progress-bar, drag-and-drop, support for all modern browsers.",
   "directories": {
     "doc": "docs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "fine-uploader",
   "title": "Fine Uploader",
+  "main": "lib/traditional.js",
   "version": "5.8.0",
   "description": "Multiple file upload component with progress-bar, drag-and-drop, support for all modern browsers.",
   "directories": {
@@ -53,10 +54,11 @@
   },
   "devDependencies": {
     "async": "0.2.9",
+    "fs-sync": "1.0.2",
     "glob": "3.2.6",
     "grunt": "^0.4.5",
     "grunt-aws-s3": "^0.10.0",
-    "grunt-banner": "0.6.0",
+    "grunt-banner": "0.2.0",
     "grunt-contrib-clean": "0.4.1",
     "grunt-contrib-compress": "0.5.2",
     "grunt-contrib-concat": "0.3.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "fine-uploader",
   "title": "Fine Uploader",
   "main": "lib/traditional.js",
-  "version": "5.8.0-beta1",
+  "version": "5.8.0",
   "description": "Multiple file upload component with progress-bar, drag-and-drop, support for all modern browsers.",
   "directories": {
     "doc": "docs",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "fine-uploader",
   "title": "Fine Uploader",
   "main": "lib/traditional.js",
-  "version": "5.8.0-1",
+  "version": "5.8.0-beta1",
   "description": "Multiple file upload component with progress-bar, drag-and-drop, support for all modern browsers.",
   "directories": {
     "doc": "docs",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
   "title": "Fine Uploader",
   "version": "5.8.0",
   "description": "Multiple file upload component with progress-bar, drag-and-drop, support for all modern browsers.",
-  "main": "./fine-uploader/js/fineuploader.js",
   "directories": {
     "doc": "docs",
     "lib": "client",
@@ -57,7 +56,7 @@
     "glob": "3.2.6",
     "grunt": "^0.4.5",
     "grunt-aws-s3": "^0.10.0",
-    "grunt-banner": "0.2.0",
+    "grunt-banner": "0.6.0",
     "grunt-contrib-clean": "0.4.1",
     "grunt-contrib-compress": "0.5.2",
     "grunt-contrib-concat": "0.3.0",


### PR DESCRIPTION
- [x] Allow access to `qq` object via CommonJS
- [x] Allow access to `qq` object via AMD
- [x] Ensure `qq` is global only if CommonJS or AMD are not available
- [x] Make it easier to import/require each bundled js file
- [x] Expose css files in CommonJS lib dir as: "legacy.css", "rows.css", and "gallery.css".
- [x] Update docs to illustrate CommonJS support & integration w/ ES6 modules + Webpack
- [x] Update fineuploader.com w/ module support
- [ ] Release to master/develop + git tag
- [x] blog.fineuploader.com for 5.8.0 release
- [ ] Release 5.8.0 on npm
- [ ] Make 5.8.0 available for download on fineuploader.com
- [ ] Tweet 5.8.0 release

This will complete #789.