### PR TITLE
fix(session): Fixed a problem with the session requester cors request

### DIFF
--- a/client/js/uploader.basic.api.js
+++ b/client/js/uploader.basic.api.js
@@ -1631,7 +1631,7 @@
             /* jshint eqnull:true */
             if (qq.Session && this._options.session.endpoint != null) {
                 if (!this._session) {
-                    qq.extend(options, this._options.cors);
+                    qq.extend(options, {cors: this._options.cors});
 
                     options.log = qq.bind(this.log, this);
                     options.addFileRecord = qq.bind(this._addCannedFile, this);


### PR DESCRIPTION
## Brief description of the changes
Fixed a problem with the CORS request for session not working correctly.

More detailed explanation:

From [the docs](http://docs.fineuploader.com/branch/master/features/CORS.html):

> If you set the `cors.expected` property to true, it is assumed that all requests will be cross-domain requests

This PR addresses a problem that seems to have been introduced in [this commit](https://github.com/FineUploader/fine-uploader/commit/f40705a91ac22244b4b0ca1acbfa11391b680f0c). On [L1634 of uploader.basic.api.js](https://github.com/FineUploader/fine-uploader/blob/d23eaf371a6170c7f468b0df86ce5a6585094854/client/js/uploader.basic.api.js#L1634), the options for the Session requester are extended as such:

```js
qq.extend(options, this._options.cors);
```

Making the session request (calling `_refreshSessionData()`) will never send a request with credentials using these options:

```js
{
...
  cors: {
    expected: true,
    sendCredentials: true
  },
...
}
```

Expanding the options L1634 (from above), the line looks like this:

```js
qq.extend(options, {expected: true, sendCredentials: true});
```

Which results in the requester options looking like this:

```js
{
...
  expected: true,
  sendCredentials: true,
...
}
```

When it should look like this:

```js
{
...
  cors: {
    expected: true,
    sendCredentials: true,
  }
...
}
```

#### Workaround:
Using these options works fine:

```js
{
...
  session: {
    cors: {
      expected: true,
      sendCredentials: true
    },
  },
...
}
```

## What browsers and operating systems have you tested these changes on?
Chrome 51, OS X 10.11.3 


## Are all automated tests passing?
yes

## Is this pull request against develop or some other non-master branch?
yes