### PR TITLE
Allow a sasQuery to be specified for Azure to avoid the use of a signing endpoint

### DIFF
--- a/client/js/azure/azure.xhr.upload.handler.js
+++ b/client/js/azure/azure.xhr.upload.handler.js
@@ -113,10 +113,17 @@ qq.azure.XhrUploadHandler = function(spec, proxy) {
                 promise.failure({error: "Problem communicating with local server"}, getSasXhr);
             },
             determineBlobUrlSuccess = function(blobUrl) {
-                api.getSasForPutBlobOrBlock.request(getSasId, blobUrl).then(
-                    getSasSuccess,
-                    getSasFailure
-                );
+                // When we already have a SAS query to use then return it here without actually making a request
+                // to the default signature endpoint
+                if (signature.sasQuery && signature.endpoint == null) {
+                    getSasSuccess(blobUrl + "?" + signature.sasQuery);
+                } else {
+                    api.getSasForPutBlobOrBlock.request(getSasId, blobUrl).then(
+                        getSasSuccess,
+                        getSasFailure
+                    );
+                }
+
             },
             determineBlobUrlFailure = function(reason) {
                 log(qq.format("Failed to determine blob name for ID {} - {}", id, reason), "error");

--- a/client/js/azure/uploader.basic.js
+++ b/client/js/azure/uploader.basic.js
@@ -203,9 +203,15 @@
                     log: qq.bind(self.log, self)
                 });
 
-            getSas.request(id, blobUriStore.get(id)).then(
-                qq.bind(getSasSuccess, self, id),
-                qq.bind(getSasFailure, self, id));
+            // When we have no signing endpoint but we have a sasQuery, we can immediately call getSasSuccess with the URI
+            if (self._options.signature.sasQuery && self._options.signature.endpoint == null) {
+                getSasSuccess(id, blobUriStore.get(id) + "?" + self._options.signature.sasQuery);
+            } else {
+                getSas.request(id, blobUriStore.get(id)).then(
+                    qq.bind(getSasSuccess, self, id),
+                    qq.bind(getSasFailure, self, id));
+            }
+
         },
 
         _createDeleteHandler: function() {

--- a/docs/api/options-azure.jmd
+++ b/docs/api/options-azure.jmd
@@ -76,7 +76,8 @@ alert("The [`request.customHeaders` option](options.html#request.customHeaders) 
 {{ api_parent_option("signature", "signature", "",
     (
         ("signature.customHeaders", "customHeaders", "Additional headers sent along with each signature request.  If you declare a function as the value, the associated file's ID will be passed to your function when it is invoked.", "Object, Function", "{}",),
-        ("signature.endpoint", "endpoint", "The endpoint that Fine Uploader can use to send GET for a SAS before sending requests off to S3.  The blob URL and underlying method type associated with the underlying REST request will be included in the query string.", "String", "null",),
+        ("signature.endpoint", "endpoint", "The endpoint that Fine Uploader can use to send GET for a SAS before sending requests off to Azure.  The blob URL and underlying method type associated with the underlying REST request will be included in the query string.", "String", "null",),
+        ("signature.sasQuery", "query", "The URL encoded SAS query string that Fine Uploader can use to send requests directly to Azure, without using the signature endpoint to produce a SAS for each request.  This is disabled if the signature endpoint is set.", "String", "null",),
     )
 )}}
 


### PR DESCRIPTION
## Brief description of the changes
Allows passing of `signature.sasQuery` to Azure options. If no `signature.endpoint` is present this will use the passed query string to immediately create a SAS URI for all requests, without needing the signing endpoint to produce a SAS URI for each request.

This is what I needed to perform what I was after in #1602.

## What browsers and operating systems have you tested these changes on?
Chrome 52 on OS X

We set a stored access policy on a container and then create a SAS URI for that container with the identifier for the stored access policy and full permissions to the container. That URI, with changes to the path for the blob that actions are being take on, allows all action we need on the given container.

## Are all automated tests passing?
Yes, though I have yet to add tests for the passing of `signature.sasQuery`.

## Is this pull request against develop or some other non-master branch?
Yes
