### PR TITLE
fix(image): Fixed a problem where image previews weren't being loaded

### DIFF
--- a/client/js/image-support/image.js
+++ b/client/js/image-support/image.js
@@ -31,7 +31,7 @@ qq.ImageGenerator = function(log) {
     function determineMimeOfFileName(nameWithPath) {
         /*jshint -W015 */
         var pathSegments = nameWithPath.split("/"),
-            name = pathSegments[pathSegments.length - 1],
+            name = pathSegments[pathSegments.length - 1].split("?")[0],
             extension = qq.getExtension(name);
 
         extension = extension && extension.toLowerCase();


### PR DESCRIPTION
## Brief description of the changes [REQUIRED]
I fixed a problem where the if the thumbnail url returned from the server contained a query string, the image type defaults to jpeg, thus breaking any other file type previews

## What browsers and operating systems have you tested these changes on? [REQUIRED]
Chrome on OS X


## Are all automated tests passing? [REQUIRED]
Yes


## Is this pull request against develop or some other non-master branch? [REQUIRED]
Yes
