### PR TITLE
Issue 1661 - CustomHeaders not set on delete feature

### DIFF
--- a/client/js/azure/uploader.basic.js
+++ b/client/js/azure/uploader.basic.js
@@ -194,6 +194,7 @@
                 }),
                 getSas = new qq.azure.GetSas({
                     cors: this._options.cors,
+                    customHeaders: this._options.signature.customHeaders,
                     endpointStore: {
                         get: function() {
                             return self._options.signature.endpoint;


### PR DESCRIPTION
## Brief description of the changes
Added the `customHeaders` in the options for the getSas() method of delete function. Headers are retrieved from the `signature` attribute.
Ref: https://github.com/FineUploader/fine-uploader/issues/1661


## What browsers and operating systems have you tested these changes on?
Safari 9.1.2 OSX 10.11.6


## Are all automated tests passing?
Yes


## Is this pull request against develop or some other non-master branch?
Yes