### PR TITLE
Don't requeue uploads in the waiting queue.

### DIFF
--- a/client/js/upload-handler/upload.handler.controller.js
+++ b/client/js/upload-handler/upload.handler.controller.js
@@ -322,7 +322,11 @@ qq.UploadHandlerController = function(o, namespace) {
 
         open: function(id, chunkIdx) {
             if (chunkIdx == null) {
-                connectionManager._waiting.push(id);
+                var alreadyInWaiting = qq.indexOf(connectionManager._waiting, id);
+                var alreadyInOpen = qq.indexOf(connectionManager._open, id);
+                if (alreadyInWaiting === -1 && alreadyInOpen === -1) {
+                    connectionManager._waiting.push(id);
+                }
             }
 
             if (connectionManager.available()) {


### PR DESCRIPTION
## Brief description of the changes [REQUIRED]

Stop the connection manager from pushing an existing id into the waiting queue.

If the user calls retry twice (or any other weird race condition) the connection manager re-queues the file. Then when 'free' is called, we see that this id exists in the waiting queue. Thus we don't free the open slot or invoke the next item for upload.
This can cause the uploader to stop working entirely as the open slots are never cleared.
## What browsers and operating systems have you tested these changes on? [REQUIRED]

Chrome on Windows 10.
## Are all automated tests passing? [REQUIRED]

Yes.
## Is this pull request against develop or some other non-master branch? [REQUIRED]

Yes. Going to Develop. Did discover this issue when using 5.10.

Fixing a bug where if 'retry' is invoked on an item already in the waiting queue it gets re-queued. Which means that after the upload finishes and 'free' is called, we incorrectly don't upload the next item.
