### PR TITLE
Reject the signing promises on failure.

### DIFF
--- a/client/js/s3/request-signer.js
+++ b/client/js/s3/request-signer.js
@@ -402,6 +402,8 @@ qq.s3.RequestSigner = function(o) {
                 requestInfo.hashedContent = hashedContent;
 
                 promise.success(generateStringToSign(requestInfo));
+            }, function (err) {
+                promise.failure(err);
             });
         }
         else {
@@ -424,6 +426,8 @@ qq.s3.RequestSigner = function(o) {
 
             toBeSigned.signatureConstructor.getToSign(id).then(function(signatureArtifacts) {
                 signApiRequest(toBeSigned.signatureConstructor, signatureArtifacts.stringToSign, signatureEffort);
+            }, function (err) {
+                signatureEffort.failure(err);
             });
         }
         // Form upload (w/ policy document)
@@ -514,6 +518,9 @@ qq.s3.RequestSigner = function(o) {
                             .withParams(params)
                             .withQueryParams(queryParams)
                             .send();
+                    }, function (err) {
+                        options.log("Failed to construct signature. ", "error");
+                        signatureEffort.failure("Failed to construct signature.");
                     });
                 }
                 else {
@@ -600,6 +607,8 @@ qq.s3.RequestSigner = function(o) {
                             stringToSign: artifacts.toSign,
                             stringToSignRaw: artifacts.toSignRaw
                         });
+                    }, function (err) {
+                        promise.failure(err);
                     });
 
                     return promise;


### PR DESCRIPTION
## Brief description of the changes [REQUIRED]
If signing a file for s3 upload fails FineUploader hangs. Promises related to signing were not calling failure on their parent promises.

Repo steps:
1. Find a large file.
2. Put it in an SD card.
3. Add the file to FineUploader
4. Pull out SD card before the signing can finish.
5. Signing methods fail, rejecting their promise.
6. Promise rejection is not propagated up.


## What browsers and operating systems have you tested these changes on? [REQUIRED]
Windows 10. Chrome


## Are all automated tests passing? [REQUIRED]
Yes


## Is this pull request against develop or some other non-master branch? [REQUIRED]
Yes. Develop.

