### PR TITLE
Feature/903 allow empty file uploads

### DIFF
--- a/client/js/uploader.api.js
+++ b/client/js/uploader.api.js
@@ -326,7 +326,7 @@
 
             this._templating.updateProgress(id, loaded, total);
 
-            if (Math.round(loaded / total * 100) === 100) {
+            if (total === 0 || Math.round(loaded / total * 100) === 100) {
                 this._templating.hideCancel(id);
                 this._templating.hidePause(id);
                 this._templating.hideProgress(id);

--- a/client/js/uploader.basic.api.js
+++ b/client/js/uploader.basic.api.js
@@ -1795,7 +1795,7 @@
                 return validityChecker.failure();
             }
 
-            if (size === 0) {
+            if (!this._options.validation.allowEmpty && size === 0) {
                 this._itemError("emptyError", name, file);
                 return validityChecker.failure();
             }

--- a/client/js/uploader.basic.api.js
+++ b/client/js/uploader.basic.api.js
@@ -795,6 +795,10 @@
         },
 
         _formatSize: function(bytes) {
+            if (bytes === 0) {
+                return bytes + this._options.text.sizeSymbols[0];
+            }
+
             var i = -1;
             do {
                 bytes = bytes / 1000;


### PR DESCRIPTION
## Brief description of the changes [REQUIRED]

Adds the ability to set a validation option to allow users to upload empty (0 bytes) files, as requested in #903 
## What browsers and operating systems have you tested these changes on? [REQUIRED]

Chrome on OS X 10.10.5
## Are all automated tests passing? [REQUIRED]

yes
## Is this pull request against develop or some other non-master branch? [REQUIRED]

yes, develop
