### PR TITLE
Add adjustments to S3 module to allow for use with Google Cloud Storage buckets

### DIFF
--- a/client/js/s3/util.js
+++ b/client/js/s3/util.js
@@ -366,7 +366,7 @@ qq.s3.util = qq.s3.util || (function() {
                 adjustedMaxSize = maxSize <= 0 ? 9007199254740992 : maxSize;
 
             if (minSize > 0 || maxSize > 0) {
-                policy.conditions.push(["content-length-range", adjustedMinSize.toString(), adjustedMaxSize.toString()]);
+                policy.conditions.push(["content-length-range", Math.round(adjustedMinSize), Math.round(adjustedMaxSize)]);
             }
         },
 

--- a/client/js/s3/util.js
+++ b/client/js/s3/util.js
@@ -68,8 +68,12 @@ qq.s3.util = qq.s3.util || (function() {
             var patterns = [
                     //bucket in domain
                     /^(?:https?:\/\/)?([a-z0-9.\-_]+)\.s3(?:-[a-z0-9\-]+)?\.amazonaws\.com/i,
+                    //bucket in domain (google)
+                    /^(?:https?:\/\/)?([a-z0-9.\-_]+)\.storage(?:-[a-z0-9\-]+)?\.googleapis\.com/i,
                     //bucket in path
                     /^(?:https?:\/\/)?s3(?:-[a-z0-9\-]+)?\.amazonaws\.com\/([a-z0-9.\-_]+)/i,
+                    //bucket in path (google)
+                    /^(?:https?:\/\/)?storage(?:-[a-z0-9\-]+)?\.googleapis\.com\/([a-z0-9.\-_]+)/i,
                     //custom domain
                     /^(?:https?:\/\/)?([a-z0-9.\-_]+)/i
                 ],

--- a/test/unit/s3/util.js
+++ b/test/unit/s3/util.js
@@ -46,6 +46,10 @@ describe("s3/util.js", function () {
                 "https://s3.amazonaws.com/foo_bar_com": "foo_bar_com",
                 "s3.amazonaws.com/foo_bar_com": "foo_bar_com",
 
+                "http://storage.googleapis.com/goo-bar": "goo-bar",
+                "https://storage.googleapis.com/goo-bar": "goo-bar",
+                "storage.googleapis.com/goo-bar": "goo-bar",
+
                 "http://foo.bar.com": "foo.bar.com",
                 "https://foo.bar.com": "foo.bar.com",
                 "foo.bar.com": "foo.bar.com",


### PR DESCRIPTION
## Brief description of the changes [REQUIRED]

These changes allow for uploading to Google Cloud Storage (GCS) using the S3 part of fine-uploader (per issue #1158). 

The main change was simply to include storage.googleapis.com in the list of patterns that "detects" the bucket name when generating the policy document. 

I also had to make an additional change which specifies the content min/max length (image size) as numerics rather than as strings, due to google apparently being more strict about validating the policy document. 

Please note that the PR is showing a change to the logo in the root README.md (possibly backing out dfff19b), I'm not really sure why that happened.
## What browsers and operating systems have you tested these changes on? [REQUIRED]

{example: Safari on iOS 9.1.0 and IE11 on Windows 8.1}

Chrome on OS X El Capitan.
## Are all automated tests passing? [REQUIRED]

{Choose one: "yes" or "no". If "no", then why not?}

Yes, all automated tests passed.
## Is this pull request against develop or some other non-master branch? [REQUIRED]

{Choose one: "yes" or "no". If "no", then why not?}

In my fork I made the changes in branch 1158-s3-to-gcs-interop, then merged into my develop branch, and the PR is for develop. Let me know if you prefer it a different way. It's possible that I format the comments exactly right, I didn't see those guidelines until after I did my commits.
