### PR TITLE
S3 Signature on Worker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -118,18 +118,12 @@ s3-files-only = \
 	$(js-src-dir)/s3/multipart.complete.ajax.requester.js \
 	$(js-src-dir)/s3/multipart.abort.ajax.requester.js \
 	$(js-src-dir)/s3/s3.xhr.upload.handler.js \
-	$(js-src-dir)/s3/s3.form.upload.handler.js
+	$(js-src-dir)/s3/s3.form.upload.handler.js \
+	$(build-out-dir)/s3.fine-uploader.worker-inline.js
 
 s3-files = \
 	$(core-files) \
 	$(s3-files-only)
-
-s3-files-with-worker-only = \
-	$(build-out-dir)/s3.fine-uploader.worker-inline.js
-
-s3-files-with-worker = \
-	$(s3-files) \
-	$(s3-files-with-worker-only)
 
 s3-ui-files-only = \
 	$(js-src-dir)/s3/uploader.js
@@ -179,7 +173,6 @@ all-core-files = \
 	$(core-files) \
 	$(traditional-files-only) \
 	$(s3-files-only) \
-	$(s3-files-with-worker-only) \
 	$(azure-files-only)
 
 all-core-jquery-files = \
@@ -191,7 +184,6 @@ all-files = \
 	$(traditional-files-only) \
 	$(ui-files) \
 	$(s3-files-only) \
-	$(s3-files-with-worker-only) \
 	$(s3-ui-files-only) \
 	$(azure-files-only) \
 	$(azure-ui-files-only)
@@ -251,17 +243,11 @@ _build-s3-inline-worker: _build
 	$(uglify-worker) $(js-src-dir)/s3/worker.start.js $(cryptojs-files) $(js-src-dir)/s3/worker.end.js -o $(build-out-dir)/s3.fine-uploader.worker.min.js --source-map $(build-out-dir)/s3.fine-uploader.worker.js.map
 	node workerToInline $(build-out-dir)/s3.fine-uploader.worker.min.js $(build-out-dir)/s3.fine-uploader.worker-inline.js
 
-build-core-s3: _build
+build-core-s3: _build _build-s3-inline-worker
 	$(uglify) $(s3-files) -o $(build-out-dir)/s3.fine-uploader.core.js --source-map $(build-out-dir)/s3.fine-uploader.core.js.map
 
-build-core-s3-min: _build
+build-core-s3-min: _build _build-s3-inline-worker
 	$(uglify-min) $(s3-files) -o $(build-out-dir)/s3.fine-uploader.core.min.js --source-map $(build-out-dir)/s3.fine-uploader.core.min.js.map
-
-build-s3-files-with-worker: _build _build-s3-inline-worker
-	$(uglify) $(s3-files-with-worker) -o $(build-out-dir)/s3.fine-uploader.core.worker.js --source-map $(build-out-dir)/s3.fine-uploader.core.worker.js.map
-
-build-s3-files-with-worker-min: _build _build-s3-inline-worker
-	$(uglify-min) $(s3-files-with-worker) -o $(build-out-dir)/s3.fine-uploader.core.worker.min.js --source-map $(build-out-dir)/s3.fine-uploader.core.worker.min.js.map
 
 build-ui-s3: _build
 	$(uglify) $(s3-ui-files) -o $(build-out-dir)/s3.fine-uploader.js --source-map $(build-out-dir)/s3.fine-uploader.js.map
@@ -320,8 +306,6 @@ build: \
 	build-ui-s3-min \
 	build-ui-s3-jquery \
 	build-ui-s3-jquery-min \
-	build-s3-files-with-worker \
-	build-s3-files-with-worker-min \
 	build-core-azure \
 	build-core-azure-min \
 	build-ui-azure \
@@ -392,12 +376,6 @@ endif
 	cp $(build-out-dir)/$(PUB-SUBDIR).min* $(build-out-dir)/$(PUB-SUBDIR).js* $(pub-dir)/$(PUB-SUBDIR)
 	cp $(build-out-dir)/fine-uploader*.css* $(pub-dir)/$(PUB-SUBDIR)
 
-copy-s3-worker-to-dist:
-	cp $(build-out-dir)/$(PUB-SUBDIR).core.worker.js* \
-		$(build-out-dir)/$(PUB-SUBDIR).core.worker.min* \
-		$(build-out-dir)/$(PUB-SUBDIR).worker.min* \
-		$(pub-dir)/$(PUB-SUBDIR)/
-
 copy-dnd:
 	mkdir -p $(pub-dir)/dnd
 	cp $(build-out-dir)/dnd*.* $(pub-dir)/dnd
@@ -412,7 +390,6 @@ copy-traditional-jquery-dist:
 
 copy-s3-dist:
 	make copy-build-to-dist PUB-SUBDIR=s3.fine-uploader
-	make copy-s3-worker-to-dist PUB-SUBDIR=s3.fine-uploader
 
 copy-s3-jquery-dist:
 	make copy-build-to-dist PUB-SUBDIR=s3.jquery.fine-uploader

--- a/Makefile
+++ b/Makefile
@@ -391,6 +391,12 @@ endif
 	cp $(build-out-dir)/$(PUB-SUBDIR).min* $(build-out-dir)/$(PUB-SUBDIR).js* $(pub-dir)/$(PUB-SUBDIR)
 	cp $(build-out-dir)/fine-uploader*.css* $(pub-dir)/$(PUB-SUBDIR)
 
+copy-s3-worker-to-dist:
+	cp $(build-out-dir)/$(PUB-SUBDIR).core.worker.js* \
+		$(build-out-dir)/$(PUB-SUBDIR).core.worker.min* \
+		$(build-out-dir)/$(PUB-SUBDIR).worker.min* \
+		$(pub-dir)/$(PUB-SUBDIR)/
+
 copy-dnd:
 	mkdir -p $(pub-dir)/dnd
 	cp $(build-out-dir)/dnd*.* $(pub-dir)/dnd
@@ -405,6 +411,7 @@ copy-traditional-jquery-dist:
 
 copy-s3-dist:
 	make copy-build-to-dist PUB-SUBDIR=s3.fine-uploader
+	make copy-s3-worker-to-dist PUB-SUBDIR=s3.fine-uploader
 
 copy-s3-jquery-dist:
 	make copy-build-to-dist PUB-SUBDIR=s3.jquery.fine-uploader

--- a/Makefile
+++ b/Makefile
@@ -111,6 +111,7 @@ s3-files-only = \
 	$(js-src-dir)/s3/util.js \
 	$(js-src-dir)/non-traditional-common/uploader.basic.api.js \
 	$(js-src-dir)/s3/uploader.basic.js \
+	$(js-src-dir)/s3/request-signer.worker-manager.js \
 	$(js-src-dir)/s3/request-signer.js \
 	$(js-src-dir)/uploadsuccess.ajax.requester.js \
 	$(js-src-dir)/s3/multipart.initiate.ajax.requester.js \

--- a/Makefile
+++ b/Makefile
@@ -123,6 +123,13 @@ s3-files = \
 	$(core-files) \
 	$(s3-files-only)
 
+s3-files-with-worker-only = \
+	$(build-out-dir)/s3.fine-uploader.worker-inline.js
+
+s3-files-with-worker = \
+	$(s3-files) \
+	$(s3-files-with-worker-only)
+
 s3-ui-files-only = \
 	$(js-src-dir)/s3/uploader.js
 
@@ -171,6 +178,7 @@ all-core-files = \
 	$(core-files) \
 	$(traditional-files-only) \
 	$(s3-files-only) \
+	$(s3-files-with-worker-only) \
 	$(azure-files-only)
 
 all-core-jquery-files = \
@@ -182,6 +190,7 @@ all-files = \
 	$(traditional-files-only) \
 	$(ui-files) \
 	$(s3-files-only) \
+	$(s3-files-with-worker-only) \
 	$(s3-ui-files-only) \
 	$(azure-files-only) \
 	$(azure-ui-files-only)
@@ -210,6 +219,7 @@ _build:
 	$(npm-bin)/cleancss --source-map $@/fine-uploader-new.css -o $@/fine-uploader-new.min.css
 
 uglify = $(npm-bin)/uglifyjs -b --preamble $(preamble) -e window:global -p relative --source-map-include-sources
+uglify-worker = $(npm-bin)/uglifyjs -c -m --preamble $(preamble) -p relative --source-map-include-sources
 uglify-min = $(npm-bin)/uglifyjs -c -m --preamble $(preamble) -e window:global -p relative --source-map-include-sources
 
 build-dnd-standalone: _build
@@ -236,11 +246,21 @@ build-ui-traditional-jquery: _build
 build-ui-traditional-jquery-min: _build
 	$(uglify-min) $(traditional-ui-jquery-files) -o $(build-out-dir)/jquery.fine-uploader.min.js --source-map $(build-out-dir)/jquery.fine-uploader.min.js.map
 
+_build-s3-inline-worker: _build
+	$(uglify-worker) $(js-src-dir)/s3/worker.start.js $(cryptojs-files) $(js-src-dir)/s3/worker.end.js -o $(build-out-dir)/s3.fine-uploader.worker.min.js --source-map $(build-out-dir)/s3.fine-uploader.worker.js.map
+	node workerToInline $(build-out-dir)/s3.fine-uploader.worker.min.js $(build-out-dir)/s3.fine-uploader.worker-inline.js
+
 build-core-s3: _build
 	$(uglify) $(s3-files) -o $(build-out-dir)/s3.fine-uploader.core.js --source-map $(build-out-dir)/s3.fine-uploader.core.js.map
 
 build-core-s3-min: _build
 	$(uglify-min) $(s3-files) -o $(build-out-dir)/s3.fine-uploader.core.min.js --source-map $(build-out-dir)/s3.fine-uploader.core.min.js.map
+
+build-s3-files-with-worker: _build _build-s3-inline-worker
+	$(uglify) $(s3-files-with-worker) -o $(build-out-dir)/s3.fine-uploader.core.worker.js --source-map $(build-out-dir)/s3.fine-uploader.core.worker.js.map
+
+build-s3-files-with-worker-min: _build _build-s3-inline-worker
+	$(uglify-min) $(s3-files-with-worker) -o $(build-out-dir)/s3.fine-uploader.core.worker.min.js --source-map $(build-out-dir)/s3.fine-uploader.core.worker.min.js.map
 
 build-ui-s3: _build
 	$(uglify) $(s3-ui-files) -o $(build-out-dir)/s3.fine-uploader.js --source-map $(build-out-dir)/s3.fine-uploader.js.map
@@ -272,16 +292,16 @@ build-ui-azure-jquery: _build
 build-ui-azure-jquery-min: _build
 	$(uglify-min) $(azure-ui-jquery-files) -o $(build-out-dir)/azure.jquery.fine-uploader.min.js -e window:global --source-map $(build-out-dir)/azure.jquery.fine-uploader.min.js.map
 
-build-all-core: _build
+build-all-core: _build _build-s3-inline-worker
 	$(uglify) $(all-core-files) -o $(build-out-dir)/all.fine-uploader.core.js --source-map $(build-out-dir)/all.fine-uploader.core.js.map 
 
-build-all-core-min: _build
+build-all-core-min: _build _build-s3-inline-worker
 	$(uglify-min) $(all-core-files) -o $(build-out-dir)/all.fine-uploader.core.min.js -e window:global --source-map $(build-out-dir)/all.fine-uploader.core.min.js.map
 
-build-all-ui: _build
+build-all-ui: _build _build-s3-inline-worker
 	$(uglify) $(all-files) -o $(build-out-dir)/all.fine-uploader.js --source-map $(build-out-dir)/all.fine-uploader.js.map 
 
-build-all-ui-min: _build
+build-all-ui-min: _build _build-s3-inline-worker
 	$(uglify-min) $(all-files) -o $(build-out-dir)/all.fine-uploader.min.js --source-map $(build-out-dir)/all.fine-uploader.min.js.map
 
 build: \
@@ -299,6 +319,8 @@ build: \
 	build-ui-s3-min \
 	build-ui-s3-jquery \
 	build-ui-s3-jquery-min \
+	build-s3-files-with-worker \
+	build-s3-files-with-worker-min \
 	build-core-azure \
 	build-core-azure-min \
 	build-ui-azure \

--- a/client/js/s3/request-signer.js
+++ b/client/js/s3/request-signer.js
@@ -269,7 +269,8 @@ qq.s3.RequestSigner = function(o) {
     credentialsProvider = options.signatureSpec.credentialsProvider;
     if (options.signatureSpec.workerUrl !== null) {
         workerManager = new qq.s3.RequestSignerWorkerManager({
-            workerUrl: options.signatureSpec.workerUrl
+            workerUrl: options.signatureSpec.workerUrl,
+            log: options.log,
         });
     }
 

--- a/client/js/s3/request-signer.js
+++ b/client/js/s3/request-signer.js
@@ -33,8 +33,7 @@ qq.s3.RequestSigner = function(o) {
                 credentialsProvider: {},
                 endpoint: null,
                 customHeaders: {},
-                version: 2,
-                workerUrl: null
+                version: 2
             },
             maxConnections: 3,
             endpointStore: {},
@@ -46,7 +45,6 @@ qq.s3.RequestSigner = function(o) {
             log: function(str, level) {}
         },
         credentialsProvider,
-        workerManager,
 
         generateHeaders = function(signatureConstructor, signature, promise) {
             var headers = signatureConstructor.getHeaders();
@@ -159,8 +157,8 @@ qq.s3.RequestSigner = function(o) {
                 if (qq.isBlob(body)) {
                     // We will fallback to the inline reader if the worker was
                     // not loaded correctly
-                    if (workerManager) {
-                        promise = workerManager.generateSignature(body);
+                    if (options.signatureSpec.workerManager) {
+                        promise = options.signatureSpec.workerManager.generateSignature(body);
                         if (promise !== null) {
                             return promise;
                         }
@@ -267,12 +265,6 @@ qq.s3.RequestSigner = function(o) {
 
     qq.extend(options, o, true);
     credentialsProvider = options.signatureSpec.credentialsProvider;
-    if (options.signatureSpec.workerUrl !== null) {
-        workerManager = new qq.s3.RequestSignerWorkerManager({
-            workerUrl: options.signatureSpec.workerUrl,
-            log: options.log,
-        });
-    }
 
     function handleSignatureReceived(id, xhrOrXdr, isError) {
         var responseJson = xhrOrXdr.responseText,

--- a/client/js/s3/request-signer.js
+++ b/client/js/s3/request-signer.js
@@ -34,7 +34,7 @@ qq.s3.RequestSigner = function(o) {
                 endpoint: null,
                 customHeaders: {},
                 version: 2,
-                useWorker: false
+                workerUrl: null
             },
             maxConnections: 3,
             endpointStore: {},
@@ -46,6 +46,7 @@ qq.s3.RequestSigner = function(o) {
             log: function(str, level) {}
         },
         credentialsProvider,
+        workerManager,
 
         generateHeaders = function(signatureConstructor, signature, promise) {
             var headers = signatureConstructor.getHeaders();
@@ -153,52 +154,18 @@ qq.s3.RequestSigner = function(o) {
             },
 
             getEncodedHashedPayload: function(body) {
-                var promise = new qq.Promise(),
-                    reader,
-                    self = this;
-
+                var promise,
+                    reader;
                 if (qq.isBlob(body)) {
-                    // Only if a worker is requested will we load it.
-                    // We will fallback to the inline reader if the worker
-                    // fails to load.
-                    if (options.signatureSpec.useWorker) {
-                        if (!this._worker) {
-                            try {
-                                // allow the worker path to be overwritten.. Eg. we aren't using an inline worker.
-                                var workerUrl = options.signatureSpec.useWorker;
-                                if (workerUrl === true) {
-                                    if (!qq.s3.worker) {
-                                        throw new Error("Missing inline s3 worker.");
-                                    }
-                                    workerUrl = qq.s3.worker();
-                                }
-                                this._worker = new Worker(workerUrl);
-                                this._workerPromises = {};
-                                this._worker.onmessage = function (e) {
-                                    if (!self._workerPromises[e.data.id]) {
-                                        options.log("Worker returned a result for an request we dont know about.");
-                                        return;
-                                    }
-                                    if (e.data.err) {
-                                        self._workerPromises[e.data.id].failure(e.data.err);
-                                    } else {
-                                        self._workerPromises[e.data.id].success(e.data.resp);
-                                    }
-                                    delete self._workerPromises[e.data.id];
-                                };
-                            } catch (ex) {
-                                // worker is not supported or invalid
-                                options.log("Worker failed to be created. Defaulting back to main thread processing.", ex);
-                                options.signatureSpec.useWorker = false;
-                            }
-                        }
-                        if (this._worker) {
-                            var task = {file: body, id: qq.getUniqueId()};
-                            this._workerPromises[task.id] = promise;
-                            this._worker.postMessage(task);
+                    // We will fallback to the inline reader if the worker was
+                    // not loaded correctly
+                    if (workerManager) {
+                        promise = workerManager.generateSignature(body);
+                        if (promise !== null) {
                             return promise;
                         }
                     }
+                    promise = new qq.Promise();
                     reader = new FileReader();
                     reader.onloadend = function(e) {
                         if (e.target.readyState === FileReader.DONE) {
@@ -212,12 +179,11 @@ qq.s3.RequestSigner = function(o) {
                         }
                     };
                     reader.readAsArrayBuffer(body);
+                    return promise;
                 }
-                else {
-                    body = body || "";
-                    promise.success(qq.CryptoJS.SHA256(body).toString());
-                }
-
+                promise = new qq.Promise();
+                body = body || "";
+                promise.success(qq.CryptoJS.SHA256(body).toString());
                 return promise;
             },
 
@@ -301,6 +267,11 @@ qq.s3.RequestSigner = function(o) {
 
     qq.extend(options, o, true);
     credentialsProvider = options.signatureSpec.credentialsProvider;
+    if (options.signatureSpec.workerUrl !== null) {
+        workerManager = new qq.s3.RequestSignerWorkerManager({
+            workerUrl: options.signatureSpec.workerUrl
+        });
+    }
 
     function handleSignatureReceived(id, xhrOrXdr, isError) {
         var responseJson = xhrOrXdr.responseText,
@@ -435,7 +406,6 @@ qq.s3.RequestSigner = function(o) {
         }
 
         endOfUrl = requestInfo.key + "?" + endOfUrl;
-
         if (version === 4) {
             v4.getEncodedHashedPayload(requestInfo.content).then(function(hashedContent) {
                 requestInfo.headers["x-amz-content-sha256"] = hashedContent;

--- a/client/js/s3/request-signer.worker-manager.js
+++ b/client/js/s3/request-signer.worker-manager.js
@@ -8,6 +8,7 @@ qq.s3.RequestSignerWorkerManager = function (o) {
         _workerPromises = {},
         options = {
             workerUrl: null,
+            log: function(str, level) {}
         };
     qq.extend(options, o, true);
 
@@ -16,32 +17,41 @@ qq.s3.RequestSignerWorkerManager = function (o) {
         var workerUrl;
         switch (typeof options.workerUrl) {
         case "string":
-            if (options.workerUrl.length > 0) {
+            if (options.workerUrl !== "inline") {
                 workerUrl = options.workerUrl;
             } else {
-                if (!qq.s3.worker) {
+                if (!qq.s3.createS3InlineWorkerUrl) {
                     qq.Error("Missing inline s3 worker");
                     return;
                 }
-                workerUrl = qq.s3.worker();
+                workerUrl = qq.s3.createS3InlineWorkerUrl();
             }
-            console.log('use string worker');
             break;
         case "function":
             workerUrl = options.workerUrl();
-            console.log('use function worker');
             break;
         default:
             break;
         }
         if (!workerUrl) {
-            console.log('no worker to create');
             return;
         }
         try {
             _worker = new Worker(workerUrl);
+            _worker.onerror = function (e) {
+                // Prevent the event from bubbling
+                e.preventDefault();
+                // log the error, and fail any pending promises.
+                options.log('Worker encountered an error. Disabling. ' + e.message, "warn");
+                _worker = null;
+                var outstandingRequests = Object.keys(_workerPromises),
+                    i;
+                for (i = 0; i < outstandingRequests.length; i++) {
+                    _workerPromises[outstandingRequests[i]].failure(e);
+                    delete _workerPromises[outstandingRequests[i]];
+                }
+            };
             _worker.onmessage = function (e) {
-                console.log('worker got response', e.data);
                 if (!_workerPromises[e.data.id]) {
                     options.log("Worker returned a result for an request we dont know about.");
                     return;
@@ -49,16 +59,13 @@ qq.s3.RequestSignerWorkerManager = function (o) {
                 if (e.data.err) {
                     _workerPromises[e.data.id].failure(e.data.err);
                 } else {
-                    console.log('called success');
                     _workerPromises[e.data.id].success(e.data.resp);
                 }
                 delete _workerPromises[e.data.id];
             };
-            console.log('worker created');
         }  catch (ex) {
-            console.log('failed to create worker');
             // worker is not supported or invalid
-            options.log("Worker failed to be created. Defaulting back to main thread processing.", ex);
+            options.log("Worker failed to be created. Defaulting back to main thread processing." + ex, "warn");
             _worker = null;
         }
     }
@@ -69,11 +76,9 @@ qq.s3.RequestSignerWorkerManager = function (o) {
         @returns a promise or null if we can't generate signatures at all.
     */
     this.generateSignature = function (file) {
-        console.log('ganerate Signature Please');
         if (!_worker) {
             return null;
         }
-        console.log('posting to taks to sign');
         var promise = new qq.Promise(),
             task = {file: file, id: qq.getUniqueId()};
         _workerPromises[task.id] = promise;

--- a/client/js/s3/request-signer.worker-manager.js
+++ b/client/js/s3/request-signer.worker-manager.js
@@ -1,7 +1,8 @@
 /* globals qq, CryptoJS */
 
-
-
+/**
+ * Manages creation and communication of s3 signature workers.
+ */
 qq.s3.RequestSignerWorkerManager = function (o) {
     "use strict";
     var _worker = null,
@@ -12,26 +13,25 @@ qq.s3.RequestSignerWorkerManager = function (o) {
         };
     qq.extend(options, o, true);
 
-
     function init() {
         var workerUrl;
         switch (typeof options.workerUrl) {
-        case "string":
-            if (options.workerUrl !== "inline") {
-                workerUrl = options.workerUrl;
-            } else {
-                if (!qq.s3.createS3InlineWorkerUrl) {
-                    qq.Error("Missing inline s3 worker");
-                    return;
+            case "string":
+                if (options.workerUrl !== "inline") {
+                    workerUrl = options.workerUrl;
+                } else {
+                    if (!qq.s3.createS3InlineWorkerUrl) {
+                        qq.Error("Missing inline s3 worker");
+                        return;
+                    }
+                    workerUrl = qq.s3.createS3InlineWorkerUrl();
                 }
-                workerUrl = qq.s3.createS3InlineWorkerUrl();
-            }
-            break;
-        case "function":
-            workerUrl = options.workerUrl();
-            break;
-        default:
-            break;
+                break;
+            case "function":
+                workerUrl = options.workerUrl();
+                break;
+            default:
+                break;
         }
         if (!workerUrl) {
             return;

--- a/client/js/s3/request-signer.worker-manager.js
+++ b/client/js/s3/request-signer.worker-manager.js
@@ -1,0 +1,83 @@
+/* globals qq, CryptoJS */
+
+
+
+qq.s3.RequestSignerWorkerManager = function (o) {
+    "use strict";
+    var _worker = null,
+        _workerPromises = {},
+        options = {
+            workerUrl: null,
+        };
+    qq.extend(options, o, true);
+
+
+    function init() {
+        var workerUrl;
+        switch (typeof options.workerUrl) {
+        case "string":
+            if (options.workerUrl.length > 0) {
+                workerUrl = options.workerUrl;
+            } else {
+                if (!qq.s3.worker) {
+                    qq.Error("Missing inline s3 worker");
+                    return;
+                }
+                workerUrl = qq.s3.worker();
+            }
+            console.log('use string worker');
+            break;
+        case "function":
+            workerUrl = options.workerUrl();
+            console.log('use function worker');
+            break;
+        default:
+            break;
+        }
+        if (!workerUrl) {
+            console.log('no worker to create');
+            return;
+        }
+        try {
+            _worker = new Worker(workerUrl);
+            _worker.onmessage = function (e) {
+                console.log('worker got response', e.data);
+                if (!_workerPromises[e.data.id]) {
+                    options.log("Worker returned a result for an request we dont know about.");
+                    return;
+                }
+                if (e.data.err) {
+                    _workerPromises[e.data.id].failure(e.data.err);
+                } else {
+                    console.log('called success');
+                    _workerPromises[e.data.id].success(e.data.resp);
+                }
+                delete _workerPromises[e.data.id];
+            };
+            console.log('worker created');
+        }  catch (ex) {
+            console.log('failed to create worker');
+            // worker is not supported or invalid
+            options.log("Worker failed to be created. Defaulting back to main thread processing.", ex);
+            _worker = null;
+        }
+    }
+    init();
+    /*
+        Generates the signuare of the given file.
+        @param file the file/slice to generate the signature for.
+        @returns a promise or null if we can't generate signatures at all.
+    */
+    this.generateSignature = function (file) {
+        console.log('ganerate Signature Please');
+        if (!_worker) {
+            return null;
+        }
+        console.log('posting to taks to sign');
+        var promise = new qq.Promise(),
+            task = {file: file, id: qq.getUniqueId()};
+        _workerPromises[task.id] = promise;
+        _worker.postMessage(task);
+        return promise;
+    };
+};

--- a/client/js/s3/request-signer.worker-manager.js
+++ b/client/js/s3/request-signer.worker-manager.js
@@ -42,7 +42,7 @@ qq.s3.RequestSignerWorkerManager = function (o) {
                 // Prevent the event from bubbling
                 e.preventDefault();
                 // log the error, and fail any pending promises.
-                options.log('Worker encountered an error. Disabling. ' + e.message, "warn");
+                options.log("Worker encountered an error. Disabling. " + e.message, "warn");
                 _worker = null;
                 var outstandingRequests = Object.keys(_workerPromises),
                     i;

--- a/client/js/s3/request-signer.worker-manager.js
+++ b/client/js/s3/request-signer.worker-manager.js
@@ -20,10 +20,6 @@ qq.s3.RequestSignerWorkerManager = function (o) {
                 if (options.workerUrl !== "inline") {
                     workerUrl = options.workerUrl;
                 } else {
-                    if (!qq.s3.createS3InlineWorkerUrl) {
-                        qq.Error("Missing inline s3 worker");
-                        return;
-                    }
                     workerUrl = qq.s3.createS3InlineWorkerUrl();
                 }
                 break;

--- a/client/js/s3/s3.xhr.upload.handler.js
+++ b/client/js/s3/s3.xhr.upload.handler.js
@@ -11,6 +11,15 @@
 qq.s3.XhrUploadHandler = function(spec, proxy) {
     "use strict";
 
+    // need to pre-construct the workerManager
+    var workerManager;
+    if (spec.signature.workerUrl) {
+        workerManager = new qq.s3.RequestSignerWorkerManager({
+            workerUrl: spec.signature.workerUrl,
+            log: proxy.log,
+        });
+    }
+
     var getName = proxy.getName,
         log = proxy.log,
         clockDrift = spec.clockDrift,
@@ -26,7 +35,7 @@ qq.s3.XhrUploadHandler = function(spec, proxy) {
         region = spec.objectProperties.region,
         serverSideEncryption = spec.objectProperties.serverSideEncryption,
         validation = spec.validation,
-        signature = qq.extend({region: region, drift: clockDrift}, spec.signature),
+        signature = qq.extend({region: region, drift: clockDrift, workerManager: workerManager}, spec.signature),
         handler = this,
         credentialsProvider = spec.signature.credentialsProvider,
 

--- a/client/js/s3/worker.end.js
+++ b/client/js/s3/worker.end.js
@@ -1,0 +1,25 @@
+/**
+ * Goes at the bottom of the S3 worker.
+ * Here we define the actual task handling and communication.
+ */
+
+function doTask(body, cb) {
+    var reader = new FileReader();
+    reader.onloadend = function(e) {
+        if (e.target.readyState === FileReader.DONE) {
+            if (e.target.error) {
+                cb(e.target.error);
+            }
+            else {
+                var wordArray = qq.CryptoJS.lib.WordArray.create(e.target.result);
+                cb(null, qq.CryptoJS.SHA256(wordArray).toString());
+            }
+        }
+    };
+    reader.readAsArrayBuffer(body);
+}
+onmessage = function (e) {
+    doTask(e.data.file, function (err, str) {
+        postMessage({err: err, resp: str, id: e.data.id});
+    });
+};

--- a/client/js/s3/worker.end.js
+++ b/client/js/s3/worker.end.js
@@ -8,7 +8,9 @@ function doTask(body, cb) {
     reader.onloadend = function(e) {
         if (e.target.readyState === FileReader.DONE) {
             if (e.target.error) {
-                cb(e.target.error);
+                // report the error.
+                // first stringify->parse it as postMessage will fail to clone the error itself.
+                cb(JSON.parse(JSON.stringify(e.target.error, null, 2)));
             }
             else {
                 var wordArray = qq.CryptoJS.lib.WordArray.create(e.target.result);

--- a/client/js/s3/worker.end.js
+++ b/client/js/s3/worker.end.js
@@ -3,7 +3,10 @@
  * Here we define the actual task handling and communication.
  */
 
+/* globals postMessage: true */
+/* globals onmessage: true */
 function doTask(body, cb) {
+    "use strict";
     var reader = new FileReader();
     reader.onloadend = function(e) {
         if (e.target.readyState === FileReader.DONE) {
@@ -21,6 +24,7 @@ function doTask(body, cb) {
     reader.readAsArrayBuffer(body);
 }
 onmessage = function (e) {
+    "use strict";
     doTask(e.data.file, function (err, str) {
         postMessage({err: err, resp: str, id: e.data.id});
     });

--- a/client/js/s3/worker.start.js
+++ b/client/js/s3/worker.start.js
@@ -1,6 +1,8 @@
 /** Prefix code the the s3 worker
  *
  */
+/* global qq:true */
+
 // define qq for the CryptoJs lib.
 qq = {};
 

--- a/client/js/s3/worker.start.js
+++ b/client/js/s3/worker.start.js
@@ -1,0 +1,7 @@
+/** Prefix code the the s3 worker
+ *
+ */
+// define qq for the CryptoJs lib.
+qq = {};
+
+/** Inline worker will be appended here*/

--- a/config/karma.conf.js
+++ b/config/karma.conf.js
@@ -21,6 +21,7 @@ module.exports = function(config, options) {
             path.resolve("test/static/local/blob-maker.js"),
             path.resolve("test/static/third-party/q/q-1.0.1.js"),
             path.resolve("node_modules/pica/dist/pica.js"),
+            path.resolve("node_modules/timemachine/timemachine.min.js"),
             path.resolve("test/static/local/helpme.js"),
             path.resolve("test/unit/**/*.js")
         ],

--- a/docs/api/options-s3.jmd
+++ b/docs/api/options-s3.jmd
@@ -99,7 +99,7 @@ alert("The [`request.customHeaders` option](options.html#request.customHeaders) 
         ("signature.customHeaders", "customHeaders", "Additional headers sent along with each signature request.  If you declare a function as the value, the associated file's ID will be passed to your function when it is invoked.", "Object, Function", "{}",),
         ("signature.endpoint", "endpoint", "The endpoint that Fine Uploader can use to send policy documents (HTML form uploads) or other strings to sign (REST requests) before sending requests off to S3.", "String", "null",),
         ("signature.version", "version", "The AWS/S3 signature version to use. Currently supported values are `2` and `4`. Directly related to [`objectProperties.region`](#objectProperties.region).", "Integer", "2",),
-        ("signature.workerUrl", "workerUrl", "Make client side signature processing for v4 signatures occur in a background worker thread. Set to 'inline' to use the inline worker. Otherwise set the URL for the worker to use.", "String", "null",),
+        ("signature.workerUrl", "workerUrl", "Make client side signature processing for v4 signatures occur in a background worker thread. Set to 'inline' to use the inline worker. Otherwise set the URL for the worker to use. Default of null will disable the worker.", "String", "null",),
     )
 )}}
 

--- a/docs/api/options-s3.jmd
+++ b/docs/api/options-s3.jmd
@@ -99,7 +99,7 @@ alert("The [`request.customHeaders` option](options.html#request.customHeaders) 
         ("signature.customHeaders", "customHeaders", "Additional headers sent along with each signature request.  If you declare a function as the value, the associated file's ID will be passed to your function when it is invoked.", "Object, Function", "{}",),
         ("signature.endpoint", "endpoint", "The endpoint that Fine Uploader can use to send policy documents (HTML form uploads) or other strings to sign (REST requests) before sending requests off to S3.", "String", "null",),
         ("signature.version", "version", "The AWS/S3 signature version to use. Currently supported values are `2` and `4`. Directly related to [`objectProperties.region`](#objectProperties.region).", "Integer", "2",),
-        ("signature.useWorker", "useWorker", "Make client side signature processing for v4 signatures occur in a background worker thread. Set to true to use the inline worker. Otherwise set the URL to the worker to use.", "Boolean/String", "false",),
+        ("signature.workerUrl", "workerUrl", "Make client side signature processing for v4 signatures occur in a background worker thread. Set to 'inline' to use the inline worker. Otherwise set the URL for the worker to use.", "String", "null",),
     )
 )}}
 

--- a/docs/api/options-s3.jmd
+++ b/docs/api/options-s3.jmd
@@ -99,6 +99,7 @@ alert("The [`request.customHeaders` option](options.html#request.customHeaders) 
         ("signature.customHeaders", "customHeaders", "Additional headers sent along with each signature request.  If you declare a function as the value, the associated file's ID will be passed to your function when it is invoked.", "Object, Function", "{}",),
         ("signature.endpoint", "endpoint", "The endpoint that Fine Uploader can use to send policy documents (HTML form uploads) or other strings to sign (REST requests) before sending requests off to S3.", "String", "null",),
         ("signature.version", "version", "The AWS/S3 signature version to use. Currently supported values are `2` and `4`. Directly related to [`objectProperties.region`](#objectProperties.region).", "Integer", "2",),
+        ("signature.useWorker", "useWorker", "Make client side signature processing for v4 signatures occur in a background worker thread. Set to true to use the inline worker. Otherwise set the URL to the worker to use.", "Boolean/String", "false",),
     )
 )}}
 

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "mocha": "3.2.0",
     "node-static": "0.7.9",
     "pica": "latest",
-    "timemachine": "^0.2.8",
+    "timemachine": "0.2.8",
     "uglify-js": "2.7.5"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "mocha": "3.0.1",
     "node-static": "0.7.8 ",
     "pica": "latest",
+    "timemachine": "^0.2.8",
     "uglify-js": "2.7.0"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
   },
   "devDependencies": {
     "clean-css": "3.4.19",
+    "js-string-escape": "^1.0.1",
     "jscs": "3.0.7",
     "jshint": "2.9.2",
     "karma": "1.1.2",

--- a/test/dev/devenv.js
+++ b/test/dev/devenv.js
@@ -95,9 +95,7 @@ qq(window).attach("load", function() {
             accessKey: "AKIAIXVR6TANOGNBGANQ"
         },
         signature: {
-            endpoint: "/test/dev/handlers/vendor/fineuploader/php-s3-server/endpoint.php",
-            version: 4,
-            useWorker: true
+            endpoint: "/test/dev/handlers/vendor/fineuploader/php-s3-server/endpoint.php"
         },
         uploadSuccess: {
             endpoint: "/test/dev/handlers/vendor/fineuploader/php-s3-server/endpoint.php?success"

--- a/test/dev/devenv.js
+++ b/test/dev/devenv.js
@@ -95,7 +95,9 @@ qq(window).attach("load", function() {
             accessKey: "AKIAIXVR6TANOGNBGANQ"
         },
         signature: {
-            endpoint: "/test/dev/handlers/vendor/fineuploader/php-s3-server/endpoint.php"
+            endpoint: "/test/dev/handlers/vendor/fineuploader/php-s3-server/endpoint.php",
+            version: 4,
+            useWorker: true
         },
         uploadSuccess: {
             endpoint: "/test/dev/handlers/vendor/fineuploader/php-s3-server/endpoint.php?success"

--- a/test/unit/s3/serverless-uploads.js
+++ b/test/unit/s3/serverless-uploads.js
@@ -12,6 +12,7 @@ describe("S3 serverless upload tests", function() {
                 testSessionToken = "testSessionToken";
 
             describe("v4 signatures", function() {
+
                 it("test simple upload with only mandatory credentials specified as options", function(done) {
                     var testExpiration = new Date(Date.now() + 10000),
                         uploader = new qq.s3.FineUploaderBasic({
@@ -54,10 +55,263 @@ describe("S3 serverless upload tests", function() {
                         assert.equal(requestParams["x-amz-algorithm"], "AWS4-HMAC-SHA256");
                         assert.ok(new RegExp(testAccessKey + "\\/\\d{8}\\/us-east-1\\/s3\\/aws4_request").test(requestParams["x-amz-credential"]));
                         assert.ok(requestParams["x-amz-date"]);
-                        assert.ok(requestParams["x-amz-signature"]);
                         assert.ok(requestParams.policy);
 
                         done();
+                    });
+                });
+
+                describe("worker signature", function() {
+                    var chunkAnswers = [
+                        {
+                            expect: {
+                                headers: {
+                                    "x-amz-acl": "private",
+                                    "x-amz-meta-qqfilename": "test",
+                                    "x-amz-date": "20170103T051259Z",
+                                    "x-amz-content-sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                                    "Content-Type": "image/jpeg;charset=utf-8",
+                                    "Authorization": "AWS4-HMAC-SHA256 Credential=testAccessKey/20170103/us-east-1/s3/aws4_request,SignedHeaders=host;x-amz-acl;x-amz-content-sha256;x-amz-date;x-amz-meta-qqfilename,Signature=14fdc2d6a00d17df9567be47a31ca095b80524aeb8e79f3053af043015974430"
+                                }
+                            },
+                            response: {
+                                body: "<UploadId>123</UploadId>"
+                            }
+                        },
+                        {
+                            expect: {
+                                headers: {
+                                    "x-amz-date": "20170103T051259Z",
+                                    "x-amz-content-sha256": "f0e8f719522f251f70867928d11d65bcbf411bb90a6b179f59615034deacdef4",
+                                    "Authorization": "AWS4-HMAC-SHA256 Credential=testAccessKey/20170103/us-east-1/s3/aws4_request,SignedHeaders=host;x-amz-content-sha256;x-amz-date,Signature=a877f0f446fc54b72c39d9b880feb835b2067ae44fd88aa06a6ccaef3926e450",
+                                    "Content-Type": "text/plain;charset=utf-8"
+                                }
+                            },
+                            response: {
+                                headers: {
+                                    'ETag': '123'
+                                }
+                            }
+                        },
+                        {
+                            expect: {
+                                headers: {
+                                    "x-amz-date": "20170103T051259Z",
+                                    "x-amz-content-sha256": "f7cde1a6dc195915c61cb2ecbbd059568fd62ae69b3deec8bb9378d58fb962e1",
+                                    "Authorization": "AWS4-HMAC-SHA256 Credential=testAccessKey/20170103/us-east-1/s3/aws4_request,SignedHeaders=host;x-amz-content-sha256;x-amz-date,Signature=4f27d48c111d977828386fbb68962d9b5ee5693330d21b72bea89c161229b79e",
+                                    "Content-Type": "text/plain;charset=utf-8"
+                                }
+                            },
+                            response: {
+                                headers: {
+                                    'ETag': '124'
+                                }
+                            }
+                        },
+                        {
+                            expect: {
+                                headers: {
+                                    "x-amz-date": "20170103T051259Z",
+                                    "x-amz-content-sha256": "cb132c33557875745102c2b390aac7dcb59ba6f0df972db59aac6bf97c11f195",
+                                    "Authorization": "AWS4-HMAC-SHA256 Credential=testAccessKey/20170103/us-east-1/s3/aws4_request,SignedHeaders=host;x-amz-content-sha256;x-amz-date,Signature=2b66885e1ce095e841d306720e6990bc94871101db301b7e0ea642bc88f8f1f1",
+                                    "Content-Type": "text/plain;charset=utf-8"
+                                }
+                            },
+                            response: {
+                                headers: {
+                                    'ETag': '125'
+                                }
+                            }
+                        },
+                        {
+                            expect: {
+                                headers: {
+                                    "x-amz-date": "20170103T051259Z",
+                                    "x-amz-content-sha256": "c560b4f8b54d541e32b42a423ccbb1b43b298e9e0deee5c2c09d1e40ceb70a0b",
+                                    "Authorization": "AWS4-HMAC-SHA256 Credential=testAccessKey/20170103/us-east-1/s3/aws4_request,SignedHeaders=host;x-amz-content-sha256;x-amz-date,Signature=9925d724d5af0f9ac6ede5a32519d98c2e3034e2fff81f01cb0641bd312b6ee4",
+                                    "Content-Type": "text/plain;charset=utf-8"
+                                }
+                            },
+                            response: {
+                                headers: {
+                                    'ETag': '126'
+                                }
+                            }
+                        },
+                        {
+                            expect: {
+                                headers: {
+                                    "x-amz-date": "20170103T051259Z",
+                                    "x-amz-content-sha256": "065af8ce8639945de4edfed2f9f08a559e4916ff67b96aeaa348ab6dc2bbc9c5",
+                                    "Authorization": "AWS4-HMAC-SHA256 Credential=testAccessKey/20170103/us-east-1/s3/aws4_request,SignedHeaders=host;x-amz-content-sha256;x-amz-date,Signature=4b51bb95b32b33b19ede316192fa5f176e2397e543962f287b4ea6ab217ec9ea",
+                                    "Content-Type": "application/xml;charset=utf-8"
+                                },
+                                body: "<CompleteMultipartUpload><Part><PartNumber>1</PartNumber><ETag>123</ETag></Part><Part><PartNumber>2</PartNumber><ETag>124</ETag></Part><Part><PartNumber>3</PartNumber><ETag>125</ETag></Part><Part><PartNumber>4</PartNumber><ETag>126</ETag></Part></CompleteMultipartUpload>"
+                            },
+                            response: {
+                                headers: {
+                                    'ETag': '127'
+                                },
+                                body: "<CompleteMultipartUploadResult><Bucket>mytestbucket</Bucket><Key>test-key</Key></CompleteMultipartUploadResult>"
+                            }
+                        }
+                    ];
+                    function doTest(uploader, answers) {
+                        function handleChunk(which) {
+                            return function () {
+                                if (which >= answers.length) {
+                                    return;
+                                }
+                                assert.equal(fileTestHelper.getRequests().length, which + 1, "Wrong # of requests");
+                                var request = fileTestHelper.getRequests()[which];
+                                var checkHeaders = Object.keys(answers[which].expect.headers);
+                                for (var i = 0; i < checkHeaders.length; i++) {
+                                    console.log(checkHeaders[i], request.requestHeaders[checkHeaders[i]])
+                                    assert.equal(request.requestHeaders[checkHeaders[i]], answers[which].expect.headers[checkHeaders[i]]);
+                                }
+                                if (answers[which].expect.body) {
+                                    assert.equal(request.requestBody, answers[which].expect.body);
+                                }
+                                request.respond(200, answers[which].response.headers, answers[which].response.body);
+                                setTimeout(handleChunk(which + 1), 100);
+                            };
+                        }
+                        qqtest.downloadFileAsBlob("up.jpg", "image/jpeg").then(function (blob) {
+                            var request, requestParams;
+
+                            fileTestHelper.mockXhr();
+                            uploader.addFiles({name: "test", blob: blob});
+                            handleChunk(0)();
+                        });
+                    }
+                    it("test simple time-locked upload using default worker to sign", function(done) {
+                        // we need to lock the time, so our signature is constant
+                        timemachine.config({
+                            timestamp: 1483420379000 //'January 03, 2017 00:12:59'
+                        });
+                        var testExpiration = new Date(Date.now() + 10000),
+                            uploader = new qq.s3.FineUploaderBasic({
+                                request: {
+                                    endpoint: testS3Endpoint
+                                },
+                                signature: {
+                                    version: 4,
+                                    workerUrl: ''
+                                },
+                                objectProperties: {
+                                    key: function () {
+                                        return 'test-key';
+                                    }
+                                },
+                                chunking: {
+                                    enabled: true,
+                                    partSize: 1024
+                                },
+                                credentials: {
+                                    accessKey: testAccessKey,
+                                    secretKey: testSecretKey,
+                                    expiration: testExpiration
+                                },
+                                callbacks: {
+                                    onAllComplete: function(succeeded, failed) {
+                                        assert.equal(failed.length, 0);
+                                        timemachine.reset();
+                                        done();
+                                    },
+                                }
+                            });
+                        doTest(uploader, chunkAnswers);
+                    });
+                    it("test simple time-locked upload using no worker to sign", function(done) {
+                        // we need to lock the time, so our signature is constant
+                        timemachine.config({
+                            timestamp: 1483420379000 //'January 03, 2017 00:12:59'
+                        });
+                        var testExpiration = new Date(Date.now() + 10000),
+                            uploader = new qq.s3.FineUploaderBasic({
+                                request: {
+                                    endpoint: testS3Endpoint
+                                },
+                                signature: {
+                                    version: 4
+                                },
+                                objectProperties: {
+                                    key: function () {
+                                        return 'test-key';
+                                    }
+                                },
+                                chunking: {
+                                    enabled: true,
+                                    partSize: 1024
+                                },
+                                credentials: {
+                                    accessKey: testAccessKey,
+                                    secretKey: testSecretKey,
+                                    expiration: testExpiration
+                                },
+                                callbacks: {
+                                    onAllComplete: function(succeeded, failed) {
+                                        assert.equal(failed.length, 0);
+                                        timemachine.reset();
+                                        done();
+                                    },
+                                }
+                            });
+                        doTest(uploader, chunkAnswers);
+                    });
+                    it("test simple time-locked upload using custom worker to sign", function(done) {
+                        // we need to lock the time, so our signature is constant
+                        timemachine.config({
+                            timestamp: 1483420379000 //'January 03, 2017 00:12:59'
+                        });
+                        var fakeSignatureWorker = "" +
+                            "onmessage = function (e) {" +
+                                "postMessage({resp: '00000000002f251f70867928d11d65bcbf411bb90a6b179f59615034deacdef4', id: e.data.id});" +
+                            "};";
+                        var testExpiration = new Date(Date.now() + 10000),
+                            uploader = new qq.s3.FineUploaderBasic({
+                                request: {
+                                    endpoint: testS3Endpoint
+                                },
+                                signature: {
+                                    version: 4,
+                                    workerUrl: function () {
+                                        return URL.createObjectURL(new Blob([fakeSignatureWorker], {type: "application/javascript"}));
+                                    }
+                                },
+                                objectProperties: {
+                                    key: function () {
+                                        return 'test-key';
+                                    }
+                                },
+                                chunking: {
+                                    enabled: true,
+                                    partSize: 1024
+                                },
+                                credentials: {
+                                    accessKey: testAccessKey,
+                                    secretKey: testSecretKey,
+                                    expiration: testExpiration
+                                },
+                                callbacks: {
+                                    onAllComplete: function(succeeded, failed) {
+                                        assert.equal(failed.length, 0);
+                                        timemachine.reset();
+                                        done();
+                                    },
+                                }
+                            });
+                        // make a copy, and change the expected headers b/c of our
+                        // fake signature worker
+                        var answers = JSON.parse(JSON.stringify(chunkAnswers));
+                        for (var i = 1; i < answers.length - 1; i++) {
+                            answers[i].expect.headers["x-amz-content-sha256"] = "00000000002f251f70867928d11d65bcbf411bb90a6b179f59615034deacdef4";
+                        }
+                        answers[1].expect.headers["Authorization"] = "AWS4-HMAC-SHA256 Credential=testAccessKey/20170103/us-east-1/s3/aws4_request,SignedHeaders=host;x-amz-content-sha256;x-amz-date,Signature=e563897a58bc1841481737424d81f2401ae7ba527f925285622459ab97753128";
+                        answers[2].expect.headers["Authorization"] = "AWS4-HMAC-SHA256 Credential=testAccessKey/20170103/us-east-1/s3/aws4_request,SignedHeaders=host;x-amz-content-sha256;x-amz-date,Signature=a5956265f51d6039c8dd0df42ddef5a4bdfc8fc1b65812d6a4d55d121f3952dc";
+                        answers[3].expect.headers["Authorization"] = "AWS4-HMAC-SHA256 Credential=testAccessKey/20170103/us-east-1/s3/aws4_request,SignedHeaders=host;x-amz-content-sha256;x-amz-date,Signature=56f2da2ee333edb6d96d116ef9ea046ff2c4648e7117f2c1b6475f2dd572530a";
+                        answers[4].expect.headers["Authorization"] = "AWS4-HMAC-SHA256 Credential=testAccessKey/20170103/us-east-1/s3/aws4_request,SignedHeaders=host;x-amz-content-sha256;x-amz-date,Signature=6bbd9cbca147eab277bf18138961e43e309d08a10d13e5afd2d4b3ba51d08ad1";
+                        doTest(uploader, answers);
                     });
                 });
             });

--- a/test/unit/s3/serverless-uploads.js
+++ b/test/unit/s3/serverless-uploads.js
@@ -1,4 +1,4 @@
-/* globals describe, beforeEach, $fixture, qq, assert, it, qqtest, helpme, purl, Q */
+/* globals describe, beforeEach, $fixture, qq, assert, it, qqtest, helpme, purl, Q, timemachine */
 describe("S3 serverless upload tests", function() {
     "use strict";
 
@@ -71,7 +71,7 @@ describe("S3 serverless upload tests", function() {
                                     "x-amz-date": "20170103T051259Z",
                                     "x-amz-content-sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
                                     "Content-Type": "image/jpeg;charset=utf-8",
-                                    "Authorization": "AWS4-HMAC-SHA256 Credential=testAccessKey/20170103/us-east-1/s3/aws4_request,SignedHeaders=host;x-amz-acl;x-amz-content-sha256;x-amz-date;x-amz-meta-qqfilename,Signature=14fdc2d6a00d17df9567be47a31ca095b80524aeb8e79f3053af043015974430"
+                                    Authorization: "AWS4-HMAC-SHA256 Credential=testAccessKey/20170103/us-east-1/s3/aws4_request,SignedHeaders=host;x-amz-acl;x-amz-content-sha256;x-amz-date;x-amz-meta-qqfilename,Signature=14fdc2d6a00d17df9567be47a31ca095b80524aeb8e79f3053af043015974430"
                                 }
                             },
                             response: {
@@ -83,13 +83,13 @@ describe("S3 serverless upload tests", function() {
                                 headers: {
                                     "x-amz-date": "20170103T051259Z",
                                     "x-amz-content-sha256": "f0e8f719522f251f70867928d11d65bcbf411bb90a6b179f59615034deacdef4",
-                                    "Authorization": "AWS4-HMAC-SHA256 Credential=testAccessKey/20170103/us-east-1/s3/aws4_request,SignedHeaders=host;x-amz-content-sha256;x-amz-date,Signature=a877f0f446fc54b72c39d9b880feb835b2067ae44fd88aa06a6ccaef3926e450",
+                                    Authorization: "AWS4-HMAC-SHA256 Credential=testAccessKey/20170103/us-east-1/s3/aws4_request,SignedHeaders=host;x-amz-content-sha256;x-amz-date,Signature=a877f0f446fc54b72c39d9b880feb835b2067ae44fd88aa06a6ccaef3926e450",
                                     "Content-Type": "text/plain;charset=utf-8"
                                 }
                             },
                             response: {
                                 headers: {
-                                    'ETag': '123'
+                                    ETag: "123"
                                 }
                             }
                         },
@@ -98,13 +98,13 @@ describe("S3 serverless upload tests", function() {
                                 headers: {
                                     "x-amz-date": "20170103T051259Z",
                                     "x-amz-content-sha256": "f7cde1a6dc195915c61cb2ecbbd059568fd62ae69b3deec8bb9378d58fb962e1",
-                                    "Authorization": "AWS4-HMAC-SHA256 Credential=testAccessKey/20170103/us-east-1/s3/aws4_request,SignedHeaders=host;x-amz-content-sha256;x-amz-date,Signature=4f27d48c111d977828386fbb68962d9b5ee5693330d21b72bea89c161229b79e",
+                                    Authorization: "AWS4-HMAC-SHA256 Credential=testAccessKey/20170103/us-east-1/s3/aws4_request,SignedHeaders=host;x-amz-content-sha256;x-amz-date,Signature=4f27d48c111d977828386fbb68962d9b5ee5693330d21b72bea89c161229b79e",
                                     "Content-Type": "text/plain;charset=utf-8"
                                 }
                             },
                             response: {
                                 headers: {
-                                    'ETag': '124'
+                                    ETag: "124"
                                 }
                             }
                         },
@@ -113,13 +113,13 @@ describe("S3 serverless upload tests", function() {
                                 headers: {
                                     "x-amz-date": "20170103T051259Z",
                                     "x-amz-content-sha256": "cb132c33557875745102c2b390aac7dcb59ba6f0df972db59aac6bf97c11f195",
-                                    "Authorization": "AWS4-HMAC-SHA256 Credential=testAccessKey/20170103/us-east-1/s3/aws4_request,SignedHeaders=host;x-amz-content-sha256;x-amz-date,Signature=2b66885e1ce095e841d306720e6990bc94871101db301b7e0ea642bc88f8f1f1",
+                                    Authorization: "AWS4-HMAC-SHA256 Credential=testAccessKey/20170103/us-east-1/s3/aws4_request,SignedHeaders=host;x-amz-content-sha256;x-amz-date,Signature=2b66885e1ce095e841d306720e6990bc94871101db301b7e0ea642bc88f8f1f1",
                                     "Content-Type": "text/plain;charset=utf-8"
                                 }
                             },
                             response: {
                                 headers: {
-                                    'ETag': '125'
+                                    ETag: "125"
                                 }
                             }
                         },
@@ -128,13 +128,13 @@ describe("S3 serverless upload tests", function() {
                                 headers: {
                                     "x-amz-date": "20170103T051259Z",
                                     "x-amz-content-sha256": "c560b4f8b54d541e32b42a423ccbb1b43b298e9e0deee5c2c09d1e40ceb70a0b",
-                                    "Authorization": "AWS4-HMAC-SHA256 Credential=testAccessKey/20170103/us-east-1/s3/aws4_request,SignedHeaders=host;x-amz-content-sha256;x-amz-date,Signature=9925d724d5af0f9ac6ede5a32519d98c2e3034e2fff81f01cb0641bd312b6ee4",
+                                    Authorization: "AWS4-HMAC-SHA256 Credential=testAccessKey/20170103/us-east-1/s3/aws4_request,SignedHeaders=host;x-amz-content-sha256;x-amz-date,Signature=9925d724d5af0f9ac6ede5a32519d98c2e3034e2fff81f01cb0641bd312b6ee4",
                                     "Content-Type": "text/plain;charset=utf-8"
                                 }
                             },
                             response: {
                                 headers: {
-                                    'ETag': '126'
+                                    ETag: "126"
                                 }
                             }
                         },
@@ -143,14 +143,14 @@ describe("S3 serverless upload tests", function() {
                                 headers: {
                                     "x-amz-date": "20170103T051259Z",
                                     "x-amz-content-sha256": "065af8ce8639945de4edfed2f9f08a559e4916ff67b96aeaa348ab6dc2bbc9c5",
-                                    "Authorization": "AWS4-HMAC-SHA256 Credential=testAccessKey/20170103/us-east-1/s3/aws4_request,SignedHeaders=host;x-amz-content-sha256;x-amz-date,Signature=4b51bb95b32b33b19ede316192fa5f176e2397e543962f287b4ea6ab217ec9ea",
+                                    Authorization: "AWS4-HMAC-SHA256 Credential=testAccessKey/20170103/us-east-1/s3/aws4_request,SignedHeaders=host;x-amz-content-sha256;x-amz-date,Signature=4b51bb95b32b33b19ede316192fa5f176e2397e543962f287b4ea6ab217ec9ea",
                                     "Content-Type": "application/xml;charset=utf-8"
                                 },
                                 body: "<CompleteMultipartUpload><Part><PartNumber>1</PartNumber><ETag>123</ETag></Part><Part><PartNumber>2</PartNumber><ETag>124</ETag></Part><Part><PartNumber>3</PartNumber><ETag>125</ETag></Part><Part><PartNumber>4</PartNumber><ETag>126</ETag></Part></CompleteMultipartUpload>"
                             },
                             response: {
                                 headers: {
-                                    'ETag': '127'
+                                    ETag: "127"
                                 },
                                 body: "<CompleteMultipartUploadResult><Bucket>mytestbucket</Bucket><Key>test-key</Key></CompleteMultipartUploadResult>"
                             }
@@ -196,11 +196,11 @@ describe("S3 serverless upload tests", function() {
                                 },
                                 signature: {
                                     version: 4,
-                                    workerUrl: 'inline'
+                                    workerUrl: "inline"
                                 },
                                 objectProperties: {
                                     key: function () {
-                                        return 'test-key';
+                                        return "test-key";
                                     }
                                 },
                                 chunking: {
@@ -237,7 +237,7 @@ describe("S3 serverless upload tests", function() {
                                 },
                                 objectProperties: {
                                     key: function () {
-                                        return 'test-key';
+                                        return "test-key";
                                     }
                                 },
                                 chunking: {
@@ -271,11 +271,11 @@ describe("S3 serverless upload tests", function() {
                                 },
                                 signature: {
                                     version: 4,
-                                    workerUrl: 'http://localhost:3000/file.not.exists.js'
+                                    workerUrl: "http://localhost:3000/file.not.exists.js"
                                 },
                                 objectProperties: {
                                     key: function () {
-                                        return 'test-key';
+                                        return "test-key";
                                     }
                                 },
                                 chunking: {
@@ -304,7 +304,7 @@ describe("S3 serverless upload tests", function() {
                         answers.splice(1, 0, {
                             expect: {
                                 headers: {
-                                    'x-amz-date': undefined
+                                    "x-amz-date": undefined
                                 }
                             }
                         });
@@ -332,7 +332,7 @@ describe("S3 serverless upload tests", function() {
                                 },
                                 objectProperties: {
                                     key: function () {
-                                        return 'test-key';
+                                        return "test-key";
                                     }
                                 },
                                 chunking: {
@@ -358,10 +358,10 @@ describe("S3 serverless upload tests", function() {
                         for (var i = 1; i < answers.length - 1; i++) {
                             answers[i].expect.headers["x-amz-content-sha256"] = "00000000002f251f70867928d11d65bcbf411bb90a6b179f59615034deacdef4";
                         }
-                        answers[1].expect.headers["Authorization"] = "AWS4-HMAC-SHA256 Credential=testAccessKey/20170103/us-east-1/s3/aws4_request,SignedHeaders=host;x-amz-content-sha256;x-amz-date,Signature=e563897a58bc1841481737424d81f2401ae7ba527f925285622459ab97753128";
-                        answers[2].expect.headers["Authorization"] = "AWS4-HMAC-SHA256 Credential=testAccessKey/20170103/us-east-1/s3/aws4_request,SignedHeaders=host;x-amz-content-sha256;x-amz-date,Signature=a5956265f51d6039c8dd0df42ddef5a4bdfc8fc1b65812d6a4d55d121f3952dc";
-                        answers[3].expect.headers["Authorization"] = "AWS4-HMAC-SHA256 Credential=testAccessKey/20170103/us-east-1/s3/aws4_request,SignedHeaders=host;x-amz-content-sha256;x-amz-date,Signature=56f2da2ee333edb6d96d116ef9ea046ff2c4648e7117f2c1b6475f2dd572530a";
-                        answers[4].expect.headers["Authorization"] = "AWS4-HMAC-SHA256 Credential=testAccessKey/20170103/us-east-1/s3/aws4_request,SignedHeaders=host;x-amz-content-sha256;x-amz-date,Signature=6bbd9cbca147eab277bf18138961e43e309d08a10d13e5afd2d4b3ba51d08ad1";
+                        answers[1].expect.headers.Authorization = "AWS4-HMAC-SHA256 Credential=testAccessKey/20170103/us-east-1/s3/aws4_request,SignedHeaders=host;x-amz-content-sha256;x-amz-date,Signature=e563897a58bc1841481737424d81f2401ae7ba527f925285622459ab97753128";
+                        answers[2].expect.headers.Authorization = "AWS4-HMAC-SHA256 Credential=testAccessKey/20170103/us-east-1/s3/aws4_request,SignedHeaders=host;x-amz-content-sha256;x-amz-date,Signature=a5956265f51d6039c8dd0df42ddef5a4bdfc8fc1b65812d6a4d55d121f3952dc";
+                        answers[3].expect.headers.Authorization = "AWS4-HMAC-SHA256 Credential=testAccessKey/20170103/us-east-1/s3/aws4_request,SignedHeaders=host;x-amz-content-sha256;x-amz-date,Signature=56f2da2ee333edb6d96d116ef9ea046ff2c4648e7117f2c1b6475f2dd572530a";
+                        answers[4].expect.headers.Authorization = "AWS4-HMAC-SHA256 Credential=testAccessKey/20170103/us-east-1/s3/aws4_request,SignedHeaders=host;x-amz-content-sha256;x-amz-date,Signature=6bbd9cbca147eab277bf18138961e43e309d08a10d13e5afd2d4b3ba51d08ad1";
                         doTest(uploader, answers);
                     });
                 });

--- a/workerToInline.js
+++ b/workerToInline.js
@@ -23,7 +23,7 @@ fs.readFile(source, 'UTF-8', function (err, data) {
     let sourceCode = jsStringEscape(data);
 
     let outCode = `
-        qq.s3.worker = function () {
+        qq.s3.createS3InlineWorkerUrl = function () {
             return URL.createObjectURL(new Blob(["${sourceCode}"], {type: "application/javascript"}));
         };
     `;

--- a/workerToInline.js
+++ b/workerToInline.js
@@ -1,0 +1,37 @@
+'use strict';
+
+/** Turns the given source-code into an inline worker.
+ * Basically turning the source to string, then wrapping it
+ * in a javascript function that we can call to retrieve the blob's url.
+ */
+
+
+const fs = require('fs');
+const os = require('os');
+const jsStringEscape = require('js-string-escape');
+
+let source = process.argv[2];
+let out = process.argv[3];
+
+
+fs.readFile(source, 'UTF-8', function (err, data) {
+    if (err) {
+        console.log('workerToInline: failed to read source path');
+        os.exit(1);
+        return;
+    }
+    let sourceCode = jsStringEscape(data);
+
+    let outCode = `
+        qq.s3.worker = function () {
+            return URL.createObjectURL(new Blob(["${sourceCode}"], {type: "application/javascript"}));
+        };
+    `;
+    fs.writeFile(out, outCode, function (err) {
+        if (err) {
+            console.log('workerToInline: failed to write output');
+            os.exit(1);
+            return;
+        }
+    });
+});


### PR DESCRIPTION
## Brief description of the changes [REQUIRED]
Have the option for the S3 Signing process (v4) to be done in a worker thread. My browser no longer freezes on large files.

## What browsers and operating systems have you tested these changes on? [REQUIRED]
Windows 10
* Chrome 56.0
* Firefox 50.1.0
* Edge 38
* Internet Explorer 11

OSX
* Safari 10.0.2


## Are all automated tests passing? [REQUIRED]
Yes.
I haven't build the docs though...

## Is this pull request against develop or some other non-master branch? [REQUIRED]
Develop

## More Info
You might consider this a scary change :)

A couple things I want to point out, slash get your feedback on.

* The worker can be implemented as either Inline or as a separate file.
* From what I can find IE is the only one that doesn't support the inline worker. 
   * So I've added in a graceful fallback to just the old in 'main thread' method.
* Some people might not want the extra overhead of the inline file.
    * The extra overhead in this case is really the CryptoJS library.
   * I've made the option 'useWorker' to be able to specify a string. That way people can override with their own external worker.
* The inline worker file is generated at compile time. See the __build-s3-inline-worker_ build task.
     * It's done by concatenating 3 files.
         * worker.start.js, CyrptoJS files, worker.end.js
     * A simple script (workerToInline) then converts that file into a string and adds a function to qq.
     * We can now include the inline worker as a build file, as per normal js files.
* A new build artefact is added for the external worker.
* I've added a new S3 output that includes the inline worker. The regular output for s3 should not include it.
* Guidance on how you want the build artefacts to look like would be great. 

Feedback, changes, clarity, etc.. are all welcome.
