### PR TITLE
Allow upload with empty file

### DIFF
--- a/client/js/uploader.api.js
+++ b/client/js/uploader.api.js
@@ -326,7 +326,7 @@
 
             this._templating.updateProgress(id, loaded, total);
 
-            if (Math.round(loaded / total * 100) === 100) {
+            if (total === 0 || Math.round(loaded / total * 100) === 100) {
                 this._templating.hideCancel(id);
                 this._templating.hidePause(id);
                 this._templating.hideProgress(id);

--- a/client/js/uploader.basic.api.js
+++ b/client/js/uploader.basic.api.js
@@ -795,6 +795,9 @@
         },
 
         _formatSize: function(bytes) {
+            if (bytes === 0) {
+                return bytes + this._options.text.sizeSymbols[0];
+            }
             var i = -1;
             do {
                 bytes = bytes / 1000;

--- a/client/js/uploader.basic.api.js
+++ b/client/js/uploader.basic.api.js
@@ -1800,7 +1800,7 @@
                 return validityChecker.failure();
             }
 
-            if (size === 0) {
+            if (!this._options.validation.allowEmpty && size === 0) {
                 this._itemError("emptyError", name, file);
                 return validityChecker.failure();
             }

--- a/client/js/uploader.basic.js
+++ b/client/js/uploader.basic.js
@@ -39,7 +39,8 @@
                     maxWidth: 0,
                     minHeight: 0,
                     minWidth: 0
-                }
+                },
+                allowEmpty: false
             },
 
             callbacks: {

--- a/docs/api/options.jmd
+++ b/docs/api/options.jmd
@@ -233,6 +233,7 @@ alert("The `chunking.success.endpoint` option **only** applies to traditional up
     (
         ("validation.acceptFiles", "acceptFiles", "Used by the file selection dialog. Restrict the valid file types that appear in the selection dialog by listing valid content-type specifiers here. See docs on the [accept attribute of the `<input>` element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Input)", "Comma-delimited list of valid MIMEtypes", "null",),
         ("validation.allowedExtensions", "allowedExtensions", "Specify file valid file extensions here to restrict uploads to specific types.", "Array", "[]",),
+        ("validation.allowEmpty", "allowEmpty", "Allow file size of 0 bytes", "Boolean", "false"),
         ("validation.itemLimit", "itemLimit", "Maximum number of items that can be potentially uploaded in this session. Will reject all items that are added or retried after this limit is reached.", "Integer", "0",),
         ("validation.minSizeLimit", "minSizeLimit", "The minimum allowable size, in bytes, for an item.", "Integer", "0",),
         ("validation.sizeLimit", "sizeLimit", "The maximum allowable size, in bytes, for an item.", "Integer", "0",),
@@ -241,7 +242,7 @@ alert("The `chunking.success.endpoint` option **only** applies to traditional up
         ("validation.image.maxHeight", "image.maxHeight", "Restrict images to a maximum height in pixels (wherever possible).", "Integer", "0",),
         ("validation.image.maxWidth", "image.maxWidth", "Restrict images to a maximum width in pixels (wherever possible).", "Integer", "0",),
         ("validation.image.minHeight", "image.minHeight", "Restrict images to a minimum height in pixels (wherever possible).", "Integer", "0",),
-        ("validation.image.minWidth", "image.minWidth", "Restrict images to a minimum width in pixels (wherever possible).", "Integer", "0",),
+        ("validation.image.minWidth", "image.minWidth", "Restrict images to a minimum width in pixels (wherever possible).", "Integer", "0",)
     )
 )
 }}

--- a/test/static/local/helpme.js
+++ b/test/static/local/helpme.js
@@ -64,6 +64,7 @@ var helpme = (function () {
             };
             var default_validation = {
                 allowedExtensions: [],
+                allowEmpty: false,
                 acceptFiles: null,
                 sizeLimit: 0,
                 minSizeLimit: 0,

--- a/test/unit/uploader.basic.api.js
+++ b/test/unit/uploader.basic.api.js
@@ -516,21 +516,25 @@ describe("uploader.basic.api.js", function () {
         });
 
         it("fails if file is empty and allowEmpty is false", function() {
+            var result = 1;
             qq.isFileOrInput = function() { return true; };
-            fineuploader._fileOrBlobRejected = function() {};
+            fineuploader._fileOrBlobRejected = function() { result = -1; };
             var validationDescriptor = { size: 0 };
 
             fineuploader._validateFileOrBlobData({}, validationDescriptor)
-                .then(function() { assert.fail(); }, function() {});
+                .done(function() { assert.equal(-1, result); });
         });
 
         it("passes if file is empty and allowEmpty is true", function() {
             fineuploader._options.validation.allowEmpty = true;
+
+            var result = 1;
             qq.isFileOrInput = function() { return true; };
+            fineuploader._fileOrBlobRejected = function() { result = -1; };
             var validationDescriptor = { size: 0 };
 
             fineuploader._validateFileOrBlobData({}, validationDescriptor)
-                .then(function() {}, function() { assert.fail(); });
+                .done(function() { assert.equal(1, result); });
         });
     });
 });

--- a/test/unit/uploader.basic.api.js
+++ b/test/unit/uploader.basic.api.js
@@ -479,4 +479,30 @@ describe("uploader.basic.api.js", function () {
             uploader._handleNewFile(fileInput, 0, []);
         });
     });
+
+    describe("_formatSize", function() {
+        beforeEach(function () {
+            fineuploader = new qq.FineUploaderBasic();
+        });
+
+        it("formats 0 bytes properly", function() {
+            var formattedSize = fineuploader._formatSize(0);
+            assert.equal(formattedSize, "0kB");
+        });
+
+        it("formats kB properly", function() {
+            var formattedSize = fineuploader._formatSize(789);
+            assert.equal(formattedSize, "0.8kB");
+        });
+
+        it("formats MB properly", function() {
+            var formattedSize = fineuploader._formatSize(2123456);
+            assert.equal(formattedSize, "2.1MB");
+        });
+
+        it("formats GB properly", function() {
+            var formattedSize = fineuploader._formatSize(9602123456);
+            assert.equal(formattedSize, "9.6GB");
+        });
+    });
 });

--- a/test/unit/uploader.basic.api.js
+++ b/test/unit/uploader.basic.api.js
@@ -505,4 +505,32 @@ describe("uploader.basic.api.js", function () {
             assert.equal(formattedSize, "9.6GB");
         });
     });
+
+    describe("_validateFileOrBlobData", function() {
+        var originalFileOrInput = qq.isFileOrInput;
+        beforeEach(function () {
+            fineuploader = new qq.FineUploaderBasic();
+        });
+        afterEach(function() {
+            qq.isFileOrInput = originalFileOrInput;
+        });
+
+        it("fails if file is empty and allowEmpty is false", function() {
+            qq.isFileOrInput = function() { return true; };
+            fineuploader._fileOrBlobRejected = function() {};
+            var validationDescriptor = { size: 0 };
+
+            fineuploader._validateFileOrBlobData({}, validationDescriptor)
+                .then(function() { assert.fail(); }, function() {});
+        });
+
+        it("passes if file is empty and allowEmpty is true", function() {
+            fineuploader._options.validation.allowEmpty = true;
+            qq.isFileOrInput = function() { return true; };
+            var validationDescriptor = { size: 0 };
+
+            fineuploader._validateFileOrBlobData({}, validationDescriptor)
+                .then(function() {}, function() { assert.fail(); });
+        });
+    });
 });

--- a/test/unit/uploader.basic.api.js
+++ b/test/unit/uploader.basic.api.js
@@ -515,26 +515,22 @@ describe("uploader.basic.api.js", function () {
             qq.isFileOrInput = originalFileOrInput;
         });
 
-        it("fails if file is empty and allowEmpty is false", function() {
-            var result = 1;
+        it("fails if file is empty and allowEmpty is false", function(done) {
             qq.isFileOrInput = function() { return true; };
-            fineuploader._fileOrBlobRejected = function() { result = -1; };
+            fineuploader._fileOrBlobRejected = function() {};
             var validationDescriptor = { size: 0 };
 
             fineuploader._validateFileOrBlobData({}, validationDescriptor)
-                .done(function() { assert.equal(-1, result); });
+                .then(function() { assert.fail(); }, function() { done(); });
         });
 
-        it("passes if file is empty and allowEmpty is true", function() {
+        it("passes if file is empty and allowEmpty is true", function(done) {
             fineuploader._options.validation.allowEmpty = true;
-
-            var result = 1;
             qq.isFileOrInput = function() { return true; };
-            fineuploader._fileOrBlobRejected = function() { result = -1; };
             var validationDescriptor = { size: 0 };
 
             fineuploader._validateFileOrBlobData({}, validationDescriptor)
-                .done(function() { assert.equal(1, result); });
+                .then(function() { done(); }, function() { assert.fail(); });
         });
     });
 });


### PR DESCRIPTION
## Brief description of the changes [REQUIRED]
Implement issue #903 . Allow uploading of 0 byte files. Enhancement on pull request https://github.com/FineUploader/fine-uploader/pull/1673


## What browsers and operating systems have you tested these changes on? [REQUIRED]
Chrome 55.0.2883.95 (64-bit) on OSX 10.11.6

## Are all automated tests passing? [REQUIRED]
yes


## Is this pull request against develop or some other non-master branch? [REQUIRED]
yes
