### PR TITLE
feature: adding setStatus to the public api list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ bin/
 src
 
 npm-debug.log
+Vagrantfile
 
 test/dev/handlers/s3/composer.lock
 test/dev/handlers/traditional/files

--- a/client/js/uploader.basic.api.js
+++ b/client/js/uploader.basic.api.js
@@ -397,6 +397,28 @@
             return this._uploadData.uuidChanged(id, newUuid);
         },
 
+        /**
+         * Expose the internal status of a file id to the public api for manual state changes
+         * @public
+         *
+         * @param {Number} id,
+         * @param {String} newStatus
+         *
+         * @todo Implement the remaining methods
+         */
+        setStatus: function(id, newStatus) {
+            switch (newStatus) {
+                case qq.status.DELETED:
+                    this._handleDeleteSuccess(id);
+                    break;
+                case qq.status.DELETE_FAILED:
+                    this._handleDeleteFailed(id);
+                    break;
+                default:
+                    this.log("Method setStatus called on '" + name + "' not implemented yet for " + newStatus);
+            }
+        },
+
         uploadStoredFiles: function() {
             if (this._storedIds.length === 0) {
                 this._itemError("noFilesError");
@@ -1067,6 +1089,35 @@
             });
         },
 
+        _handleDeleteSuccess: function(id) {
+            var name = this.getName(id);
+
+            this._netUploadedOrQueued--;
+            this._netUploaded--;
+            this._handler.expunge(id);
+            this._uploadData.setStatus(id, qq.status.DELETED);
+            this.log("Delete request for '" + name + "' has succeeded.");
+        },
+
+        _handleDeleteFailed: function(id, xhrOrXdr) {
+            var name = this.getName(id);
+
+            this._uploadData.setStatus(id, qq.status.DELETE_FAILED);
+            this.log("Delete request for '" + name + "' has failed.", "error");
+
+            // Check first if xhrOrXdr is actually passed since manual status changes don't handle this.
+            if (xhrOrXdr) {
+                // For error reporting, we only have access to the response status if this is not
+                // an `XDomainRequest`.
+                if (xhrOrXdr.withCredentials === undefined) {
+                    this._options.callbacks.onError(id, name, "Delete request failed", xhrOrXdr);
+                }
+                else {
+                    this._options.callbacks.onError(id, name, "Delete request failed with response code " + xhrOrXdr.status, xhrOrXdr);
+                }
+            }
+        },
+
         // Creates an extra button element
         _initExtraButton: function(spec) {
             var button = this._createUploadButton({
@@ -1420,24 +1471,10 @@
             var name = this.getName(id);
 
             if (isError) {
-                this._uploadData.setStatus(id, qq.status.DELETE_FAILED);
-                this.log("Delete request for '" + name + "' has failed.", "error");
-
-                // For error reporting, we only have access to the response status if this is not
-                // an `XDomainRequest`.
-                if (xhrOrXdr.withCredentials === undefined) {
-                    this._options.callbacks.onError(id, name, "Delete request failed", xhrOrXdr);
-                }
-                else {
-                    this._options.callbacks.onError(id, name, "Delete request failed with response code " + xhrOrXdr.status, xhrOrXdr);
-                }
+                this._handleDeleteFailed(id, xhrOrXdr);
             }
             else {
-                this._netUploadedOrQueued--;
-                this._netUploaded--;
-                this._handler.expunge(id);
-                this._uploadData.setStatus(id, qq.status.DELETED);
-                this.log("Delete request for '" + name + "' has succeeded.");
+                this._handleDeleteSuccess(id);
             }
         },
 

--- a/client/js/uploader.basic.api.js
+++ b/client/js/uploader.basic.api.js
@@ -415,7 +415,9 @@
                     this._handleDeleteFailed(id);
                     break;
                 default:
-                    this.log("Method setStatus called on '" + name + "' not implemented yet for " + newStatus);
+                    var errorMessage = "Method setStatus called on '" + name + "' not implemented yet for " + newStatus;
+                    this.log(errorMessage);
+                    throw new qq.Error(errorMessage);
             }
         },
 
@@ -1105,16 +1107,14 @@
             this._uploadData.setStatus(id, qq.status.DELETE_FAILED);
             this.log("Delete request for '" + name + "' has failed.", "error");
 
-            // Check first if xhrOrXdr is actually passed since manual status changes don't handle this.
-            if (xhrOrXdr) {
-                // For error reporting, we only have access to the response status if this is not
-                // an `XDomainRequest`.
-                if (xhrOrXdr.withCredentials === undefined) {
-                    this._options.callbacks.onError(id, name, "Delete request failed", xhrOrXdr);
-                }
-                else {
-                    this._options.callbacks.onError(id, name, "Delete request failed with response code " + xhrOrXdr.status, xhrOrXdr);
-                }
+            // Check first if xhrOrXdr is actually passed or valid
+            // For error reporting, we only have access to the response status if this is not
+            // an `XDomainRequest`.
+            if (!xhrOrXdr || xhrOrXdr.withCredentials === undefined) {
+                this._options.callbacks.onError(id, name, "Delete request failed", xhrOrXdr);
+            }
+            else {
+                this._options.callbacks.onError(id, name, "Delete request failed with response code " + xhrOrXdr.status, xhrOrXdr);
             }
         },
 

--- a/docs/api/methods.jmd
+++ b/docs/api/methods.jmd
@@ -25,7 +25,7 @@ $(document).ready(function() {
 # Methods <small>Traditional</small> {: .page-header }
 {% endmarkdown %}
 
-<div class="all-methods data-spy="scroll" data-target="">
+<div class="all-methods" data-spy="scroll" data-target="">
 <div class="methods-core">
 {% markdown %}
 ## Core
@@ -545,6 +545,38 @@ A `resizeInfo` object, which will be passed to your (optional) `customResizer` f
         "name": "uuid",
         "type": "String",
         "description": "The new file UUID."
+    }
+], null) }}
+
+{{ api_method("setStatus", "setStatus (id, newStatus])",
+""" Modify the status of an file.
+
+The status values correspond to those found in the `qq.status` object. For reference:
+
+* `SUBMITTED`
+* `QUEUED`
+* `UPLOADING`
+* `UPLOAD_RETRYING`
+* `UPLOAD_FAILED`
+* `UPLOAD_SUCCESSFUL`
+* `CANCELED`
+* `REJECTED`
+* `DELETED`
+* `DELETING`
+* `DELETE_FAILED`
+* `PAUSED`
+
+""",
+[
+    {
+        "name": "id",
+        "type": "Integer",
+        "description": "The file id."
+    },
+    {
+        "name": "newStatus",
+        "type": "String",
+        "description": "An integer corresponding to a file."
     }
 ], null) }}
 

--- a/test/unit/set-status.js
+++ b/test/unit/set-status.js
@@ -1,6 +1,6 @@
 /* globals describe, beforeEach, qq, qqtest, assert, helpme, it */
 
-describe("set-status.js", function () {
+describe("set-status.js", function() {
     "use strict";
 
     var testUploadEndpoint = "/test/upload",
@@ -14,7 +14,7 @@ describe("set-status.js", function () {
         uuid: "949d16c3-727a-4c3c-8c0f-23404dcd6f3b"
     }];
 
-    it("testing status change of DELETED with initialFiles", function () {
+    it("testing status change of DELETED with initialFiles", function() {
         var uploader = new qq.FineUploaderBasic();
         uploader.addInitialFiles(initialFiles);
 
@@ -30,7 +30,7 @@ describe("set-status.js", function () {
         assert.equal(qq.status.DELETED, file.status);
     });
 
-    it("testing status change of DELETE_FAILED with initialFiles", function () {
+    it("testing status change of DELETE_FAILED with initialFiles", function() {
         var uploader = new qq.FineUploaderBasic();
         uploader.addInitialFiles(initialFiles);
 
@@ -46,7 +46,7 @@ describe("set-status.js", function () {
         assert.equal(qq.status.DELETE_FAILED, file.status);
     });
 
-    it("testing status change of DELETED with mock uploader", function () {
+    it("testing status change of DELETED with mock uploader", function(done) {
         var uploader = new qq.FineUploaderBasic({
             autoUpload: true,
             request: {
@@ -60,21 +60,23 @@ describe("set-status.js", function () {
             uploader.addFiles({name: "test", blob: blob});
             uploader.uploadStoredFiles();
             fileTestHelper.getRequests()[0].respond(201, null, JSON.stringify({success: true}));
+
+            var uploaderFiles = uploader.getUploads();
+            var file = uploaderFiles[0];
+
+            uploader.setStatus(file.id, qq.status.DELETED);
+
+            uploaderFiles = uploader.getUploads();
+            file = uploaderFiles[0];
+
+            assert.equal(0, uploader.getNetUploads());
+            assert.equal(qq.status.DELETED, file.status);
+            done();
         });
 
-        var uploaderFiles = uploader.getUploads();
-        var file = uploaderFiles[0];
-
-        uploader.setStatus(file.id, qq.status.DELETED);
-
-        uploaderFiles = uploader.getUploads();
-        file = uploaderFiles[0];
-
-        assert.equal(0, uploader.getNetUploads());
-        assert.equal(qq.status.DELETED, file.status);
     });
 
-    it("testing status change of DELETED with mock uploader", function () {
+    it("testing status change of DELETED with mock uploader", function(done) {
         var uploader = new qq.FineUploaderBasic({
             autoUpload: true,
             request: {
@@ -88,18 +90,20 @@ describe("set-status.js", function () {
             uploader.addFiles({name: "test", blob: blob});
             uploader.uploadStoredFiles();
             fileTestHelper.getRequests()[0].respond(201, null, JSON.stringify({success: true}));
+
+            var uploaderFiles = uploader.getUploads();
+            var file = uploaderFiles[0];
+
+            uploader.setStatus(file.id, qq.status.DELETE_FAILED);
+
+            uploaderFiles = uploader.getUploads();
+            file = uploaderFiles[0];
+
+            assert.equal(1, uploader.getNetUploads());
+            assert.equal(qq.status.DELETE_FAILED, file.status);
+            done();
         });
 
-        var uploaderFiles = uploader.getUploads();
-        var file = uploaderFiles[0];
-
-        uploader.setStatus(file.id, qq.status.DELETE_FAILED);
-
-        uploaderFiles = uploader.getUploads();
-        file = uploaderFiles[0];
-
-        assert.equal(1, uploader.getNetUploads());
-        assert.equal(qq.status.DELETE_FAILED, file.status);
     });
 
 });

--- a/test/unit/set-status.js
+++ b/test/unit/set-status.js
@@ -1,0 +1,101 @@
+/* globals describe, beforeEach, qq, qqtest, assert, it */
+
+describe("set-status.js", function () {
+    "use strict";
+
+    var testUploadEndpoint = "/test/upload",
+        fileTestHelper = helpme.setupFileTests();
+
+    var initialFiles = [{
+        name: "left.jpg",
+        uuid: "e109af57-848b-4c2a-bca8-051374d01db1"
+    }, {
+        name: "right.jpg",
+        uuid: "949d16c3-727a-4c3c-8c0f-23404dcd6f3b"
+    }];
+
+    it("testing status change of DELETED with initialFiles", function () {
+        var uploader = new qq.FineUploaderBasic();
+        uploader.addInitialFiles(initialFiles);
+
+        var uploaderFiles = uploader.getUploads();
+        var file = uploaderFiles[0];
+
+        uploader.setStatus(file.id, qq.status.DELETED);
+
+        uploaderFiles = uploader.getUploads();
+        file = uploaderFiles[0];
+
+        assert.equal(qq.status.DELETED, file.status);
+    });
+
+    it("testing status change of DELETE_FAILED with initialFiles", function () {
+        var uploader = new qq.FineUploaderBasic();
+        uploader.addInitialFiles(initialFiles);
+
+        var uploaderFiles = uploader.getUploads();
+        var file = uploaderFiles[1];
+
+        uploader.setStatus(file.id, qq.status.DELETE_FAILED);
+
+        uploaderFiles = uploader.getUploads();
+        file = uploaderFiles[1];
+
+        assert.equal(qq.status.DELETE_FAILED, file.status);
+    });
+
+    it("testing status change of DELETED with mock uploader", function () {
+        var uploader = new qq.FineUploaderBasic({
+            autoUpload: true,
+            request: {
+                endpoint: testUploadEndpoint
+            }
+        });
+
+        qqtest.downloadFileAsBlob("up.jpg", "image/jpeg").then(function(blob) {
+            fileTestHelper.mockXhr();
+
+            uploader.addFiles({name: "test", blob: blob});
+            uploader.uploadStoredFiles();
+            fileTestHelper.getRequests()[0].respond(201, null, JSON.stringify({success: true}));
+        });
+
+        var uploaderFiles = uploader.getUploads();
+        var file = uploaderFiles[0];
+
+        uploader.setStatus(file.id, qq.status.DELETED);
+
+        uploaderFiles = uploader.getUploads();
+        file = uploaderFiles[0];
+
+        assert.equal(qq.status.DELETED, file.status);
+    });
+
+    it("testing status change of DELETED with mock uploader", function () {
+        var uploader = new qq.FineUploaderBasic({
+            autoUpload: true,
+            request: {
+                endpoint: testUploadEndpoint
+            }
+        });
+
+        qqtest.downloadFileAsBlob("up.jpg", "image/jpeg").then(function(blob) {
+            fileTestHelper.mockXhr();
+
+            uploader.addFiles({name: "test", blob: blob});
+            uploader.uploadStoredFiles();
+            fileTestHelper.getRequests()[0].respond(201, null, JSON.stringify({success: true}));
+        });
+
+        var uploaderFiles = uploader.getUploads();
+        var file = uploaderFiles[0];
+
+        uploader.setStatus(file.id, qq.status.DELETE_FAILED);
+
+        uploaderFiles = uploader.getUploads();
+        file = uploaderFiles[0];
+
+        assert.equal(qq.status.DELETE_FAILED, file.status);
+    });
+
+});

--- a/test/unit/set-status.js
+++ b/test/unit/set-status.js
@@ -26,6 +26,7 @@ describe("set-status.js", function () {
         uploaderFiles = uploader.getUploads();
         file = uploaderFiles[0];
 
+        assert.equal(1, uploader.getNetUploads());
         assert.equal(qq.status.DELETED, file.status);
     });
 
@@ -41,6 +42,7 @@ describe("set-status.js", function () {
         uploaderFiles = uploader.getUploads();
         file = uploaderFiles[1];
 
+        assert.equal(2, uploader.getNetUploads());
         assert.equal(qq.status.DELETE_FAILED, file.status);
     });
 
@@ -68,6 +70,7 @@ describe("set-status.js", function () {
         uploaderFiles = uploader.getUploads();
         file = uploaderFiles[0];
 
+        assert.equal(0, uploader.getNetUploads());
         assert.equal(qq.status.DELETED, file.status);
     });
 
@@ -95,6 +98,7 @@ describe("set-status.js", function () {
         uploaderFiles = uploader.getUploads();
         file = uploaderFiles[0];
 
+        assert.equal(1, uploader.getNetUploads());
         assert.equal(qq.status.DELETE_FAILED, file.status);
     });
 

--- a/test/unit/set-status.js
+++ b/test/unit/set-status.js
@@ -1,4 +1,4 @@
-/* globals describe, beforeEach, qq, qqtest, assert, it */
+/* globals describe, beforeEach, qq, qqtest, assert, helpme, it */
 
 describe("set-status.js", function () {
     "use strict";


### PR DESCRIPTION
## Brief description of the changes

setStatus with DELETE and DELETE_FAILED
extract onDeleteComplete if/else into _handleDeleteSuccess / _handleDeleteFailed ?
written unit tests.

## What browsers and operating systems have you tested these changes on?
unit tests

## Are all automated tests passing? 
yes

## Is this pull request against develop or some other non-master branch?
yes
