### PR TITLE
feat(uploader.api.js) added `id` and `uuid` to `showConfirm()`

### DIFF
--- a/client/js/uploader.api.js
+++ b/client/js/uploader.api.js
@@ -523,7 +523,7 @@
                 self = this,
                 retVal;
 
-            retVal = this._options.showConfirm(confirmMessage, id, uuid);
+            retVal = this._options.showConfirm(confirmMessage, id);
 
             if (qq.isGenericPromise(retVal)) {
                 retVal.then(function() {

--- a/client/js/uploader.api.js
+++ b/client/js/uploader.api.js
@@ -523,7 +523,7 @@
                 self = this,
                 retVal;
 
-            retVal = this._options.showConfirm(confirmMessage);
+            retVal = this._options.showConfirm(confirmMessage, id, uuid);
 
             if (qq.isGenericPromise(retVal)) {
                 retVal.then(function() {

--- a/client/typescript/fine-uploader.d.ts
+++ b/client/typescript/fine-uploader.d.ts
@@ -1606,7 +1606,7 @@ declare namespace FineUploader {
      * function for `showConfirm` option
      */
     interface ShowConfirmFunction {
-        (message: string): PromiseOptions | void;
+        (message: string, id: number): PromiseOptions | void;
     }
 
     /**
@@ -1926,7 +1926,7 @@ declare namespace FineUploader {
          * 
          * The provided function may return a promise if one wishes to do asynchronous work whilst waiting for user input
          * 
-         * @default `function(message) { window.confirm(message); }`
+         * @default `function(message, id) { window.confirm(message); }`
          */
         showConfirm?: ShowConfirmFunction;
         /**

--- a/docs/api/options-ui.jmd
+++ b/docs/api/options-ui.jmd
@@ -42,7 +42,7 @@ can be overridden.
 
 {{ api_option("showMessage", "showMessage", "Provide a function here to display a message to the user when the uploader receives an error or the user attempts to leave the page. The provided function may return a promise if one wishes to do asynchronous work whilst waiting for user input.", "Function", "function(message) { window.alert(message); }") }}
 
-{{ api_option("showConfirm", "showConfirm", "Provide a function here to prompt the user to confirm deletion of a file. The provided function may return a promise if one wishes to do asynchronous work whilst waiting for user input.", "Function", "function(message, id, uuid) { window.confirm(message); }") }}
+{{ api_option("showConfirm", "showConfirm", "Provide a function here to prompt the user to confirm deletion of a file. The provided function may return a promise if one wishes to do asynchronous work whilst waiting for user input.", "Function", "function(message, id) { window.confirm(message); }") }}
 
 {{ api_option("showPrompt", "showPrompt", "Provide a function here to prompt the user for a filename when pasting file(s). The provided function may return a promise if one wishes to do asynchronous work whilst waiting for user input.", "Function", "function(message, defaultValue) { window.prompt(message, defaultValue); }") }}
 

--- a/docs/api/options-ui.jmd
+++ b/docs/api/options-ui.jmd
@@ -42,7 +42,7 @@ can be overridden.
 
 {{ api_option("showMessage", "showMessage", "Provide a function here to display a message to the user when the uploader receives an error or the user attempts to leave the page. The provided function may return a promise if one wishes to do asynchronous work whilst waiting for user input.", "Function", "function(message) { window.alert(message); }") }}
 
-{{ api_option("showConfirm", "showConfirm", "Provide a function here to prompt the user to confirm deletion of a file. The provided function may return a promise if one wishes to do asynchronous work whilst waiting for user input.", "Function", "function(message) { window.confirm(message); }") }}
+{{ api_option("showConfirm", "showConfirm", "Provide a function here to prompt the user to confirm deletion of a file. The provided function may return a promise if one wishes to do asynchronous work whilst waiting for user input.", "Function", "function(message, id, uuid) { window.confirm(message); }") }}
 
 {{ api_option("showPrompt", "showPrompt", "Provide a function here to prompt the user for a filename when pasting file(s). The provided function may return a promise if one wishes to do asynchronous work whilst waiting for user input.", "Function", "function(message, defaultValue) { window.prompt(message, defaultValue); }") }}
 

--- a/docs/features/styling.jmd
+++ b/docs/features/styling.jmd
@@ -248,7 +248,7 @@ as you see fit.  This is possible by overriding the `showMessage` function optio
 simply invokes `alert` with the message text.  One instance in which this is used is when the user attempts to select an
 invalid file for upload.  There are general message types with default text that can be overriden as well.
 
-* `showConfirm: function(message) {...}` - This function is used to display a confirm dialog.  One
+* `showConfirm: function(message, id, uuid) {...}` - This function is used to display a confirm dialog.  One
 such feature that optionally uses this is the `deleteFile` feature. Note that **this
 is a promissory callback**, meaning it requires a [promise](async-tasks-and-promises.html) to
 be returned.The default implementation uses `window.confirm`, but you

--- a/docs/features/styling.jmd
+++ b/docs/features/styling.jmd
@@ -248,7 +248,7 @@ as you see fit.  This is possible by overriding the `showMessage` function optio
 simply invokes `alert` with the message text.  One instance in which this is used is when the user attempts to select an
 invalid file for upload.  There are general message types with default text that can be overriden as well.
 
-* `showConfirm: function(message, id, uuid) {...}` - This function is used to display a confirm dialog.  One
+* `showConfirm: function(message, id) {...}` - This function is used to display a confirm dialog.  One
 such feature that optionally uses this is the `deleteFile` feature. Note that **this
 is a promissory callback**, meaning it requires a [promise](async-tasks-and-promises.html) to
 be returned.The default implementation uses `window.confirm`, but you


### PR DESCRIPTION
## Brief description of the changes
Added `id` and `uuid` to `showConfirm()`.  I personally have 2 reasons for this:

- I want the $mdDialog to animate from the button which was pressed
- I do virus scanning on upload files and when a user presses "delete" for a file which has been rejected, I don't want the confirm dialog to be shown

## What browsers and operating systems have you tested these changes on? 
N/A

## Are all automated tests passing? 
yes

## Is this pull request against develop or some other non-master branch? 
develop
