### PR TITLE
feat(uploader*.api.js): addInitialFiles() accepts non-successful files.

### DIFF
--- a/client/js/uploader.api.js
+++ b/client/js/uploader.api.js
@@ -373,14 +373,7 @@
                     self._markFileAsSuccessful(id);
                 }
                 else {
-                    qq(fileContainer).addClass(self._classes.fail);
-                    templating.showCancel(id);
-
-                    if (templating.isRetryPossible() && !self._preventRetries[id]) {
-                        qq(fileContainer).addClass(self._classes.retryable);
-                        templating.showRetry(id);
-                    }
-                    self._controlFailureTextDisplay(id, result);
+                    self._markFileAsFailed(id, result);
                 }
             }
 
@@ -408,6 +401,20 @@
             qq(templating.getFileContainer(id)).addClass(this._classes.success);
 
             this._maybeUpdateThumbnail(id);
+        },
+
+        _markFileAsFailed: function(id, result) {
+            var templating = this._templating,
+                fileContainer = templating.getFileContainer(id);
+
+            qq(fileContainer).addClass(this._classes.fail);
+            templating.showCancel(id);
+
+            if (templating.isRetryPossible() && !this._preventRetries[id]) {
+                qq(fileContainer).addClass(this._classes.retryable);
+                templating.showRetry(id);
+            }
+            this._controlFailureTextDisplay(id, result);
         },
 
         _onUploadPrep: function(id) {
@@ -706,7 +713,12 @@
             this._addToList(id, this.getName(id), true);
             this._templating.hideSpinner(id);
             this._templating.hideCancel(id);
-            this._markFileAsSuccessful(id);
+            if (sessionData.status == qq.status.UPLOAD_SUCCESSFUL) {
+                this._markFileAsSuccessful(id);
+            } else {
+                this._preventRetries[id] = true;
+                this._markFileAsFailed(id, sessionData);
+            }
 
             return id;
         },

--- a/client/js/uploader.api.js
+++ b/client/js/uploader.api.js
@@ -713,7 +713,7 @@
             this._addToList(id, this.getName(id), true);
             this._templating.hideSpinner(id);
             this._templating.hideCancel(id);
-            if (sessionData.status == qq.status.UPLOAD_SUCCESSFUL) {
+            if (sessionData.status === qq.status.UPLOAD_SUCCESSFUL) {
                 this._markFileAsSuccessful(id);
             } else {
                 this._preventRetries[id] = true;

--- a/client/js/uploader.api.js
+++ b/client/js/uploader.api.js
@@ -713,7 +713,7 @@
             this._addToList(id, this.getName(id), true);
             this._templating.hideSpinner(id);
             this._templating.hideCancel(id);
-            if (sessionData.status === qq.status.UPLOAD_SUCCESSFUL) {
+            if (sessionData.status !== qq.status.UPLOAD_FAILED) {
                 this._markFileAsSuccessful(id);
             } else {
                 this._preventRetries[id] = true;

--- a/client/js/uploader.basic.api.js
+++ b/client/js/uploader.basic.api.js
@@ -456,8 +456,10 @@
                 this._thumbnailUrls[id] = sessionData.thumbnailUrl;
             }
 
-            this._netUploaded++;
-            this._netUploadedOrQueued++;
+            if (sessionData.status !== qq.status.UPLOAD_FAILED) {
+                this._netUploaded++;
+                this._netUploadedOrQueued++;
+            }
 
             return id;
         },

--- a/client/js/uploader.basic.api.js
+++ b/client/js/uploader.basic.api.js
@@ -446,7 +446,7 @@
                 uuid: sessionData.uuid,
                 name: sessionData.name,
                 size: sessionData.size,
-                status: qq.status.UPLOAD_SUCCESSFUL
+                status: sessionData.status || qq.status.UPLOAD_SUCCESSFUL
             });
 
             sessionData.deleteFileEndpoint && this.setDeleteFileEndpoint(sessionData.deleteFileEndpoint, id);

--- a/docs/features/session.jmd
+++ b/docs/features/session.jmd
@@ -66,7 +66,7 @@ Here are the following properties of each `Object` that Fine Uploader recognizes
 * *s3Key: `String` - Key of the file in your S3 bucket.  Only required if using Fine Uploader S3.
 * *s3Bucket: `String` - Name of the bucket where the file is stored in S3.  Only required if using Fine Uploader S3 and if the bucket cannot be determined by examining the endpoint URL (such as when routing through a CDN).
 * *blobName: `String` - Name of the file in your Azure Blob Storage container.  Only required if using Fine Uploader Azure.
-* status: `String` - defaults to `upload successful`
+* status: `String` - Either `qq.status.UPLOAD_SUCCESSFUL` (default) or `qq.status.UPLOAD_FAILED`
 
 The response will be converted into a JavaScript `Array` and passed to your `sessionRequestComplete` event handler.
 So, any non-standard object properties passed with your server response will also be passed to your event handler.

--- a/docs/features/session.jmd
+++ b/docs/features/session.jmd
@@ -66,6 +66,7 @@ Here are the following properties of each `Object` that Fine Uploader recognizes
 * *s3Key: `String` - Key of the file in your S3 bucket.  Only required if using Fine Uploader S3.
 * *s3Bucket: `String` - Name of the bucket where the file is stored in S3.  Only required if using Fine Uploader S3 and if the bucket cannot be determined by examining the endpoint URL (such as when routing through a CDN).
 * *blobName: `String` - Name of the file in your Azure Blob Storage container.  Only required if using Fine Uploader Azure.
+* status: `String` - defaults to `upload successful`
 
 The response will be converted into a JavaScript `Array` and passed to your `sessionRequestComplete` event handler.
 So, any non-standard object properties passed with your server response will also be passed to your event handler.

--- a/test/unit/session.js
+++ b/test/unit/session.js
@@ -52,6 +52,49 @@ describe("file list initialization tests", function() {
         assert.equal(uploader.getRemainingAllowedItems(), 3, "wrong number of remaining allowed items");
     });
 
+    it("adds SUCCESSFUL and FAILED items to the initial file list via API", function() {
+        var uploader = new qq.FineUploaderBasic({
+            validation: {
+                itemLimit: 5
+            }
+        });
+
+        uploader.addInitialFiles([
+            {
+                name: "failed.jpg",
+                uuid: "123",
+                size: 456,
+                status: qq.status.UPLOAD_FAILED
+            },
+            {
+                name: "successful.jpg",
+                uuid: "abc",
+                status: qq.status.UPLOAD_SUCCESSFUL
+            }
+        ]);
+
+        assert.equal(uploader.getUploads().length, 2, "wrong number of pre-populated uploads recorded");
+        assert.equal(uploader.getUploads({status: qq.status.UPLOAD_FAILED}).length, 1, "did not find failed upload");
+        assert.equal(uploader.getUploads({status: qq.status.UPLOAD_SUCCESSFUL}).length, 1, "did not find successful upload");
+
+        assert.equal(uploader.getUuid(0), "123", "123 UUID was not recorded");
+        assert.equal(uploader.getUuid(1), "abc", "abc UUID was not recorded");
+
+        assert.equal(uploader.getSize(0), 456, "wrong size for first file");
+        assert.equal(uploader.getSize(1), -1, "wrong size for second file");
+
+        assert.equal(uploader.getName(0), "failed.jpg", "wrong name for first file");
+        assert.equal(uploader.getName(1), "successful.jpg", "wrong name for second file");
+
+        assert.equal(uploader.getFile(0), null, "unexpected return value for getFile");
+        assert.equal(uploader.getFile(1), null, "unexpected return value for getFile");
+
+        assert.equal(uploader.getInProgress(), 0, "unexpected getInProgress value");
+        assert.equal(uploader.getNetUploads(), 1, "unexpected getNetUploads value");
+
+        assert.equal(uploader.getRemainingAllowedItems(), 4, "wrong number of remaining allowed items");
+    });
+
     it("adds valid items to the initial file list via GET request", function(done) {
         var expectedSessionResponse = [
                 {


### PR DESCRIPTION
## Brief description of the changes 

If status is not provided, defaults to UPLOAD_SUCCESSFUL
My current project requires that files are scanned for viruses when uploaded, and when the user refreshes the page, the front end should query the back-end and be able to show files which were clean or contain viruses.  To do this, I need to call `addInitialFiles()` with some having `status = qq.status.UPLOAD_FAILED`

## What browsers and operating systems have you tested these changes on?
Chrome (not really applicable)

## Are all automated tests passing? 
check CI results


## Is this pull request against develop or some other non-master branch?
develop
