### PR TITLE
Fix s3 pause/continue chunked multiple bug.

### DIFF
--- a/client/js/s3/s3.xhr.upload.handler.js
+++ b/client/js/s3/s3.xhr.upload.handler.js
@@ -109,7 +109,7 @@ qq.s3.XhrUploadHandler = function(spec, proxy) {
                         log(qq.format("Upload of item {}.{} cancelled. Upload will not start after successful signature request.", id, chunkIdx));
                         promise.failure({error: "Chunk upload cancelled"});
                     }
-                    else {
+                    else if (!handler._getFileState(id).paused){
                         var url = domain + "/" + endOfUrl;
                         handler._registerProgressHandler(id, chunkIdx, chunkData.size);
                         upload.track(id, xhr, chunkIdx).then(promise.success, promise.failure);

--- a/client/js/upload-handler/upload.handler.controller.js
+++ b/client/js/upload-handler/upload.handler.controller.js
@@ -592,6 +592,7 @@ qq.UploadHandlerController = function(o, namespace) {
          * Sends the file identified by id
          */
         upload: function(id) {
+            handler._getFileState(id).paused = false;
             if (connectionManager.open(id)) {
                 return upload.start(id);
             }

--- a/client/js/upload-handler/xhr.upload.handler.js
+++ b/client/js/upload-handler/xhr.upload.handler.js
@@ -118,8 +118,7 @@ qq.XhrUploadHandler = function(spec) {
                     name: uploadData.name,
                     remaining: uploadData.chunking.remaining,
                     size: uploadData.size,
-                    uuid: uploadData.uuid,
-                    loaded: uploadData.loaded
+                    uuid: uploadData.uuid
                 };
 
                 if (uploadData.key) {

--- a/client/js/upload-handler/xhr.upload.handler.js
+++ b/client/js/upload-handler/xhr.upload.handler.js
@@ -118,7 +118,8 @@ qq.XhrUploadHandler = function(spec) {
                     name: uploadData.name,
                     remaining: uploadData.chunking.remaining,
                     size: uploadData.size,
-                    uuid: uploadData.uuid
+                    uuid: uploadData.uuid,
+                    loaded: uploadData.loaded
                 };
 
                 if (uploadData.key) {


### PR DESCRIPTION
Reproduce:
s3.XhrUploadHandler
options:
, chunking: { enabled: true, concurrent: { enabled: true } }
, maxConnections: 3
, multiple: true
, resume: { enabled: true}

Chrome: Version 56.0.2924.87 (64-bit) (also on Edge)

Begin uploading a large file. Pause and continue the upload a few times
and notice that immediately or eventually (it's sporadic) the upload will
be paused but chunks will still upload in the background.

Solution: the paused state is not cleared on upload continue. initHeaders
promise success seems to be called even though the XHR is aborted. Added
file status pause check here to prevent an XHR PUT when file hsa been
paused.

