### PR TITLE
corrected case of `client/commonJs`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -363,7 +363,7 @@ zip-all:
 setup-dist:
 	mkdir -p $(pub-dir)
 	cp LICENSE README.md package.json $(pub-dir)
-	cp -pR $(src-dir)/commonjs/ $(pub-dir)/lib/
+	cp -pR $(src-dir)/commonJs/ $(pub-dir)/lib/
 	cp -pR $(src-dir)/typescript $(pub-dir)/
 
 copy-build-to-dist:


### PR DESCRIPTION
## Brief description of the changes
`make setup-dist` failed because `client/commonjs` could not be found

## What browsers and operating systems have you tested these changes on?
Linux

## Have you written unit tests? If not, explain why.
No
