### PR TITLE
set default content-type for uploads

### DIFF
--- a/client/js/s3/util.js
+++ b/client/js/s3/util.js
@@ -136,6 +136,9 @@ qq.s3.util = qq.s3.util || (function() {
             if (type) {
                 conditions.push({"Content-Type": type});
             }
+            else {
+                conditions.push({"Content-Type": "application/octet-stream"});
+            }
 
             // jscs:disable requireCamelCaseOrUpperCaseIdentifiers
             if (expectedStatus) {
@@ -265,6 +268,8 @@ qq.s3.util = qq.s3.util || (function() {
 
             if (type) {
                 awsParams["Content-Type"] = type;
+            } else {
+                awsParams["Content-Type"] = "application/octet-stream";
             }
             // jscs:disable requireCamelCaseOrUpperCaseIdentifiers
             if (expectedStatus) {


### PR DESCRIPTION
If the browser can't figure out a content-type, set a generic one, to avoid policy errors on missing content-type.

## Brief description of the changes
This fixes https://github.com/FineUploader/fine-uploader/issues/1841

## What browsers and operating systems have you tested these changes on?
Tested with Chrome 58 on Linux and Ceph/radosgw/s3 10.2.3

## Have you written unit tests? If not, explain why.
Don't know how :( but willing to learn...