### PR TITLE
Fix extraButtons typescript define not correct

### DIFF
--- a/client/typescript/fine-uploader.d.ts
+++ b/client/typescript/fine-uploader.d.ts
@@ -1547,7 +1547,7 @@ declare namespace FineUploader {
         /**
          * ExtraButtonsOptions
          */
-        extraButtons?: ExtraButtonsOptions;
+        extraButtons?: ExtraButtonsOptions[];
         /**
          * FormOptions
          */


### PR DESCRIPTION
Brief description of the changes

extraButtons in typescript define not correct. Due to document, this option allow an array of ExtraButtonsOptions

What browsers and operating systems have you tested these changes on?

NA
Have you written unit tests? If not, explain why.

NA