### PR TITLE
Fixed Drag'n'Drop for Firefox 54

### DIFF
--- a/client/js/dnd.js
+++ b/client/js/dnd.js
@@ -215,15 +215,15 @@ qq.DragAndDrop = function(o) {
     // * IE10+: If the file is dragged out of the window too quickly, IE does not set the expected values of the
     //          event's X & Y properties.
     function leavingDocumentOut(e) {
-        if (qq.firefox()) {
-            return !e.relatedTarget;
-        }
-
         if (qq.safari()) {
             return e.x < 0 || e.y < 0;
         }
 
-        return e.x === 0 && e.y === 0;
+        if ("x" in e && "y" in e) {
+            return e.x === 0 && e.y === 0;
+        }
+
+        return !e.relatedTarget;
     }
 
     function setupDragDrop() {


### PR DESCRIPTION
## Brief description of the changes
Fix for #1862 
Reordered checks in `leavingDocumentOut` in order to try use `e.x` and `e.y`, before falling back on `e.relatedTarget`.

## What browsers and operating systems have you tested these changes on?
Windows 8.1 x64 - Worked with Firefox 47 **and** 54. 
_I don't know if this has anything to do with it: https://bugzilla.mozilla.org/show_bug.cgi?id=962251)_
(Works in Chrome 59 too.)

## Have you written unit tests? If not, explain why.
Did not find any unit tests for drag and drop.
