### PR TITLE
fixed - removing console error target.onload() for while img preview

### DIFF
--- a/client/js/image-support/megapix-image.js
+++ b/client/js/image-support/megapix-image.js
@@ -383,7 +383,7 @@
                 renderImageToDataURL(self.srcImage, self.blob, opt, doSquash)
                     .then(function(dataUri) {
                         target.src = dataUri;
-                        oldTargetSrc === target.src && target.onload();
+                        oldTargetSrc === target.src;
                     });
             }());
         } else if (tagName === "canvas") {


### PR DESCRIPTION
## Brief description of the changes
This commit fixes #1882 
 
Removing invalid function onload on img element. 