### PR TITLE
Double Thumbnail loading (#1936) Fix

### DIFF
--- a/client/js/templating.js
+++ b/client/js/templating.js
@@ -993,6 +993,7 @@ qq.Templating = function(spec) {
 
         updateThumbnail: function(id, thumbnailUrl, showWaitingImg, customResizeFunction) {
             if (!this.isHiddenForever(id)) {
+                if(showWaitingImg !== true) { return; }
                 thumbGenerationQueue.push({customResizeFunction: customResizeFunction, update: true, id: id, thumbnailUrl: thumbnailUrl, showWaitingImg: showWaitingImg});
                 !thumbnailQueueMonitorRunning && generateNextQueuedPreview();
             }


### PR DESCRIPTION
See Issue #1936 for more Infos

## Brief description of the changes
Changes related to #1936 

## What browsers and operating systems have you tested these changes on?
Chrome on MacOS

## Have you written unit tests? If not, explain why.
I have not written unit tests, because I dont have the complete overview over the code and do not have the time to working into it and setting up a proper environment to develop tests for this piece of code.
The fix I presented in #1936 is just a suggestion and is working in my situation. There should be someone other, who looks at it and test the change with a look at the full code.
