### PR TITLE
fix(templating.js): reset caused duplicate template contents (#1945)

### DIFF
--- a/client/js/templating.js
+++ b/client/js/templating.js
@@ -650,6 +650,7 @@ qq.Templating = function(spec) {
         },
 
         reset: function() {
+            container.innerHTML = "";
             this.render();
         },
 

--- a/test/unit/templating.js
+++ b/test/unit/templating.js
@@ -328,6 +328,11 @@ describe("templating.js", function() {
             assert.ok(!$fixture.find(".qq-upload-pause-selector").hasClass(HIDE_CSS));
             assert.ok(!$fixture.find(".qq-upload-spinner-selector").hasClass(HIDE_CSS));
         });
+
+        it("reset clears contents before appending new render", function() {
+            templating.reset();
+            assert.equal($fixture.find(".qq-uploader").length, 1);
+        });
     });
 
     describe("permanently hidden files tests", function() {


### PR DESCRIPTION
Fix for #1945. Calling render resulted in duplicate template renders in the container.  This bug was introduced in the 5.15.3 release due to a change whereby templates renders are now appended to the container instead of replacing the innerHTML.

PR includes a simple unit test to verify calling render no longer results in duplicate contents.