### PR TITLE
Adding a option to getParams and expandParams

### DIFF
--- a/client/js/uploader.basic.api.js
+++ b/client/js/uploader.basic.api.js
@@ -270,6 +270,10 @@
             return this._uploadData.retrieve(optionalFilter);
         },
 
+        getParams: function(params, id) {
+            this._paramsStore.get(params, id);
+        },
+
         getUuid: function(id) {
             return this._uploadData.retrieve({id: id}).uuid;
         },
@@ -391,6 +395,10 @@
 
         setParams: function(params, id) {
             this._paramsStore.set(params, id);
+        },
+
+        extendParams: function(params, id) {
+            this._paramsStore.extend(params, id);
         },
 
         setUuid: function(id, newUuid) {
@@ -552,6 +560,19 @@
                     }
                     else {
                         store[id] = copy(val);
+                    }
+                },
+                
+                extend: function(val, id) {
+                    /*jshint eqeqeq: true, eqnull: true*/
+                    if (id == null) {
+                        store = {};
+                        catchall = catchall || {};
+                        qq.extend(catchall, val);
+                    }
+                    else {
+                        store[id] = store[id] || {};
+                        qq.extend(store[id], val);
                     }
                 },
 

--- a/client/js/uploader.basic.api.js
+++ b/client/js/uploader.basic.api.js
@@ -271,7 +271,7 @@
         },
 
         getParams: function(id) {
-            this._paramsStore.get(id);
+            return this._paramsStore.get(id);
         },
 
         getUuid: function(id) {

--- a/client/js/uploader.basic.api.js
+++ b/client/js/uploader.basic.api.js
@@ -270,8 +270,8 @@
             return this._uploadData.retrieve(optionalFilter);
         },
 
-        getParams: function(params, id) {
-            this._paramsStore.get(params, id);
+        getParams: function(id) {
+            this._paramsStore.get(id);
         },
 
         getUuid: function(id) {

--- a/docs/api/methods.jmd
+++ b/docs/api/methods.jmd
@@ -316,16 +316,18 @@ A `resizeInfo` object, which will be passed to the supplied function, contains t
 {{ api_method("getParams", "getParams (id)", "Get the parameters for an upload request. Pass in a file id to make the parameters specific to that file.",
 [
     {
-        "name": "params",
-        "type": "Object",
-        "description": "The parameters to include in the upload request."
-    },
-    {
         "name": "id",
         "type": "Integer",
         "description": "The file id."
     }
-], null) }}
+],
+[
+    {
+        "type": "Object",
+        "description": "Object containing parameters for the upload request."
+    }
+
+]) }}
 
 {{ api_method("getUuid", "getUuid (id)", "Returns the UUID of the item with the associated id.",
 [

--- a/docs/api/methods.jmd
+++ b/docs/api/methods.jmd
@@ -311,6 +311,20 @@ A `resizeInfo` object, which will be passed to the supplied function, contains t
 
 ]) }}
 
+{{ api_method("getParams", "getParams (params[, id])", "Get the parameters for an upload request. Pass in a file id to make the parameters specific to that file.",
+[
+    {
+        "name": "params",
+        "type": "Object",
+        "description": "The parameters to include in the upload request."
+    },
+    {
+        "name": "id",
+        "type": "Integer",
+        "description": "The file id."
+    }
+], null) }}
+
 {{ api_method("getUuid", "getUuid (id)", "Returns the UUID of the item with the associated id.",
 [
     {
@@ -521,6 +535,20 @@ A `resizeInfo` object, which will be passed to your (optional) `customResizer` f
 ], null) }}
 
 {{ api_method("setParams", "setParams (params[, id])", "Set the parameters for an upload request. Pass in a file id to make the parameters specific to that file.",
+[
+    {
+        "name": "params",
+        "type": "Object",
+        "description": "The parameters to include in the upload request."
+    },
+    {
+        "name": "id",
+        "type": "Integer",
+        "description": "The file id."
+    }
+], null) }}
+
+{{ api_method("extendParams", "extendParams (params[, id])", "Extend the parameters for an upload request. Pass in a file id to make the parameters specific to that file.",
 [
     {
         "name": "params",

--- a/docs/api/methods.jmd
+++ b/docs/api/methods.jmd
@@ -313,7 +313,7 @@ A `resizeInfo` object, which will be passed to the supplied function, contains t
 
 ]) }}
 
-{{ api_method("getParams", "getParams (params[, id])", "Get the parameters for an upload request. Pass in a file id to make the parameters specific to that file.",
+{{ api_method("getParams", "getParams (id)", "Get the parameters for an upload request. Pass in a file id to make the parameters specific to that file.",
 [
     {
         "name": "params",


### PR DESCRIPTION
currently the only function to set params ( "setParams" ) will replace the current data with new data, this is not always enough.
Adding "getParams" and "expandParams" will add the option to manipulate the params without erase them.
Without this options it is not possible to update multiple times the params from different sources.

i think this 2 simple functions are useful, what do you think?