### PR TITLE
Fix reported path when file name also occurs in parent directory name(s)

### DIFF
--- a/client/js/dnd.js
+++ b/client/js/dnd.js
@@ -34,19 +34,7 @@ qq.DragAndDrop = function(o) {
 
         if (entry.isFile) {
             entry.file(function(file) {
-                var name = entry.name,
-                    fullPath = entry.fullPath,
-                    indexOfNameInFullPath = fullPath.indexOf(name);
-
-                // remove file name from full path string
-                fullPath = fullPath.substr(0, indexOfNameInFullPath);
-
-                // remove leading slash in full path string
-                if (fullPath.charAt(0) === "/") {
-                    fullPath = fullPath.substr(1);
-                }
-
-                file.qqPath = fullPath;
+                file.qqPath = extractDirectoryPath(entry);
                 droppedFiles.push(file);
                 parseEntryPromise.success();
             },
@@ -83,6 +71,22 @@ qq.DragAndDrop = function(o) {
         }
 
         return parseEntryPromise;
+    }
+
+    function extractDirectoryPath(entry) {
+        var name = entry.name,
+            fullPath = entry.fullPath,
+            indexOfNameInFullPath = fullPath.lastIndexOf(name);
+
+        // remove file name from full path string
+        fullPath = fullPath.substr(0, indexOfNameInFullPath);
+
+        // remove leading slash in full path string
+        if (fullPath.charAt(0) === "/") {
+            fullPath = fullPath.substr(1);
+        }
+
+        return fullPath;
     }
 
     // Promissory.  Guaranteed to read all files in the root of the passed directory.
@@ -304,6 +308,9 @@ qq.DragAndDrop = function(o) {
             });
         }
     });
+
+    this._testing = {};
+    this._testing.extractDirectoryPath = extractDirectoryPath;
 };
 
 qq.DragAndDrop.callbacks = function() {

--- a/client/js/version.js
+++ b/client/js/version.js
@@ -1,2 +1,2 @@
 /*global qq */
-qq.version = "5.15.6";
+qq.version = "5.15.7";

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "title": "Fine Uploader",
   "main": "lib/traditional.js",
   "types" : "typescript/fine-uploader.d.ts",
-  "version": "5.15.6",
+  "version": "5.15.7",
   "description": "Multiple file upload plugin with progress-bar, drag-and-drop, direct-to-S3 & Azure uploading, client-side image scaling, preview generation, form support, chunking, auto-resume, and tons of other features.",
   "keywords": [
     "amazon",

--- a/test/unit/dnd.js
+++ b/test/unit/dnd.js
@@ -230,4 +230,29 @@ describe("drag and drop", function () {
     assert(uploadDropZone._testing.isValidFileDrag(ieFileDragEvent), "IE file drag events are valid file drags");
   });
 
+  it("extracts directory path from entries", function() {
+    var dnd = new qq.DragAndDrop();
+
+    var entry = {
+      name: "a.txt",
+      fullPath: "/data/a.txt"
+    };
+
+    var directoryPath = dnd._testing.extractDirectoryPath(entry);
+
+    assert.equal(directoryPath, "data/");
+  });
+
+  it("properly extracts directory path when file name occurs in parent directory names", function() {
+    var dnd = new qq.DragAndDrop();
+
+    var entry = {
+      name: "data",
+      fullPath: "/data/data"
+    };
+
+    var directoryPath = dnd._testing.extractDirectoryPath(entry);
+
+    assert.equal(directoryPath, "data/");
+  });
 });


### PR DESCRIPTION
## Brief description of the changes
Fixes reported path (qqpath) in case when the file name in question appears in one of its parent directory names, see #1976. The original code used indexOf so if the first occurrence was not a file name itself, it stripped way too much from the path.

## What browsers and operating systems have you tested these changes on?
Chrome 64.0.3282.167, FF 58.0.2, Edge 41.16299.248.0

## Have you written unit tests? If not, explain why.
Unit tests are present, both for normal case where I used the value the current code returns as a reference, and for the case when directory name is the same as the file name.
