### PR TITLE
refactor: use native JSON.parse, drops IE7 support

### DIFF
--- a/client/js/s3/request-signer.js
+++ b/client/js/s3/request-signer.js
@@ -272,7 +272,7 @@ qq.s3.RequestSigner = function(o) {
         // Attempt to parse what we would expect to be a JSON response
         if (responseJson) {
             try {
-                response = qq.parseJson(responseJson);
+                response = JSON.parse(responseJson);
             }
             catch (error) {
                 options.log("Error attempting to parse signature response: " + error, "error");

--- a/client/js/session.ajax.requester.js
+++ b/client/js/session.ajax.requester.js
@@ -30,7 +30,7 @@ qq.SessionAjaxRequester = function(spec) {
         /* jshint eqnull:true */
         if (xhrOrXdr.responseText != null) {
             try {
-                response = qq.parseJson(xhrOrXdr.responseText);
+                response = JSON.parse(xhrOrXdr.responseText);
             }
             catch (err) {
                 options.log("Problem parsing session response: " + err.message, "error");

--- a/client/js/traditional/traditional.xhr.upload.handler.js
+++ b/client/js/traditional/traditional.xhr.upload.handler.js
@@ -106,7 +106,7 @@ qq.traditional.XhrUploadHandler = function(spec, proxy) {
 
             try {
                 log(qq.format("Received response status {} with body: {}", xhr.status, xhr.responseText));
-                response = qq.parseJson(xhr.responseText);
+                response = JSON.parse(xhr.responseText);
             }
             catch (error) {
                 upload && spec.requireSuccessJson && log("Error when attempting to parse xhr response text (" + error.message + ")", "error");

--- a/client/js/upload-handler/form.upload.handler.js
+++ b/client/js/upload-handler/form.upload.handler.js
@@ -290,7 +290,7 @@ qq.FormUploadHandler = function(spec) {
             var response = {};
 
             try {
-                response = qq.parseJson(innerHtmlOrMessage);
+                response = JSON.parse(innerHtmlOrMessage);
             }
             catch (error) {
                 log("Error when attempting to parse iframe upload response (" + error.message + ")", "error");

--- a/client/js/uploadsuccess.ajax.requester.js
+++ b/client/js/uploadsuccess.ajax.requester.js
@@ -39,7 +39,7 @@ qq.UploadSuccessAjaxRequester = function(o) {
         options.log(qq.format("Received the following response body to an upload success request for id {}: {}", id, responseJson));
 
         try {
-            parsedResponse = qq.parseJson(responseJson);
+            parsedResponse = JSON.parse(responseJson);
 
             // If this is a cross-origin request, the server may return a 200 response w/ error or success properties
             // in order to ensure any specific error message is picked up by Fine Uploader for all browsers,

--- a/client/js/util.js
+++ b/client/js/util.js
@@ -799,19 +799,6 @@ var qq = function(element) {
     };
 
     /**
-     * Not recommended for use outside of Fine Uploader since this falls back to an unchecked eval if JSON.parse is not
-     * implemented.  For a more secure JSON.parse polyfill, use Douglas Crockford's json2.js.
-     */
-    qq.parseJson = function(json) {
-        /*jshint evil: true*/
-        if (window.JSON && qq.isFunction(JSON.parse)) {
-            return JSON.parse(json);
-        } else {
-            return eval("(" + json + ")");
-        }
-    };
-
-    /**
      * Retrieve the extension of a file, if it exists.
      *
      * @param filename

--- a/test/unit/util.js
+++ b/test/unit/util.js
@@ -650,16 +650,6 @@ describe("util.js", function () {
         });
     }); // obj2FormData
 
-    describe("parseJson", function () {
-        it("parses JSON", function () {
-            var object = { a: "a", b: "b"},
-                json = JSON.stringify(object),
-                parsedJson = JSON.parse(json);
-
-            assert.deepEqual(qq.parseJson(json), parsedJson);
-        });
-    }); // parseJson
-
     describe("isFileOrInput", function () {
         it("detects and identifies an input of type file", function () {
             var input;


### PR DESCRIPTION
Currently `eval()` is only used for IE7 and prevents sites from implementing content security policies.

Refs #1438, #1529