### PR TITLE
Clarified that callbacks are FineUploader option.

### DIFF
--- a/docs/api/events.jmd
+++ b/docs/api/events.jmd
@@ -45,6 +45,8 @@ callbacks: {
 }
 ```
 
+where `callbacks` is specified as a FineUploader option.
+
 {% endmarkdown %}
 <div class="events-all">
 

--- a/docs/api/options.jmd
+++ b/docs/api/options.jmd
@@ -56,6 +56,11 @@ mode you are in and keep that in mind when determining the meaning of a particul
 )
 }}
 
+{{ api_parent_option("callbacks", "callbacks", "Provide event handlers for almost any point in the upload process in order to unlock the full potential of Fine Uploader. See the [Events page](./events.html) for more details.",
+    ()
+)
+}}
+
 {{ api_parent_option("camera", "camera", "",
     (
         ("camera.button", "button", "`null` allows camera access on the default button in iOS. Otherwise provide an extra button container element to target.", "HTMLElement", "null",),
@@ -265,6 +270,7 @@ alert("The `chunking.success.endpoint` option **only** applies to traditional up
     )
 )
 }}
+
 </div>
 </div>
 


### PR DESCRIPTION
Thanks for this awesome library!
I have been using it on a project to perform upload to Azure from browser with completely custom UI.

## Brief description of the changes
I had hard time figuring out where to define `callbacks` while reading docs, as it is never explicitly stated that `callbacks` is a FineUploader option. I ended up trying different things and at the end it worked if I would provide as FineUploader option. Therefore, I thought it would be useful to explicitly state that in docs, and that is what this PR does.

## What browsers and operating systems have you tested these changes on?
None, because I did not manage to run building of documentation. I inspected Makefile and tried downloading docfu manually but realized that should probably not be the way to build it and stopped there, because I don't have a good idea how to build it.
Therefore, I am not sure how the PR is going to render. If you could point me toward the way to do this I will, or you can try it out and fix any errors.

## Have you written unit tests? If not, explain why.
No, because I changed only documentation.
