### PR TITLE
S3: enable overriding x-amz-date from signing server

### DIFF
--- a/client/js/s3/util.js
+++ b/client/js/s3/util.js
@@ -329,6 +329,10 @@ qq.s3.util = qq.s3.util || (function() {
                     }
                     else if (spec.signatureVersion === 4) {
                         awsParams[qq.s3.util.V4_SIGNATURE_PARAM_NAME] = policyAndSignature.signature;
+
+                        if (policyAndSignature.date) {
+                            awsParams[qq.s3.util.DATE_PARAM_NAME] = policyAndSignature.date;
+                        }
                     }
 
                     if (updatedSessionToken) {


### PR DESCRIPTION
## Brief description of the changes

AWS S3 SDK using PostObjectV4 (https://docs.aws.amazon.com/aws-sdk-php/v3/api/class-Aws.S3.PostObjectV4.html) doesnt let you set custom date for policy, and sometimes the dates are different about a second, so the better way for me is setting the date from server.

Maybe even better way would be setting the whole `awsParams` from server.


## What browsers and operating systems have you tested these changes on?
macos chrome


## Have you written unit tests? If not, explain why.
I didnt find existing matching test for this.