### PR TITLE
Fix an issue where onAllComplete can be called multiple times per addFile() call

### DIFF
--- a/client/js/uploader.basic.api.js
+++ b/client/js/uploader.basic.api.js
@@ -982,6 +982,7 @@
             return this._uploadData.retrieve({
                 status: [
                     qq.status.UPLOADING,
+                    qq.status.UPLOAD_FINALIZING,
                     qq.status.UPLOAD_RETRYING,
                     qq.status.QUEUED,
                     qq.status.SUBMITTING,


### PR DESCRIPTION
_getNotFinished, which is used to determine when to fire the onAllComplete callback, wasn't accounting for files in the UPLOAD_FINALIZING state. For smaller files, this could cause onAllComplete to be called multiple times per set of files passed to addFiles().

Note, the expected result is for onAllComplete() to be called only once per call to addFiles().