### PR TITLE
Call target.onload() only when defined

### DIFF
--- a/client/js/image-support/megapix-image.js
+++ b/client/js/image-support/megapix-image.js
@@ -383,7 +383,7 @@
                 renderImageToDataURL(self.srcImage, self.blob, opt, doSquash)
                     .then(function(dataUri) {
                         target.src = dataUri;
-                        oldTargetSrc === target.src && target.onload();
+                        oldTargetSrc === target.src && target.onload && target.onload();
                     });
             }());
         } else if (tagName === "canvas") {


### PR DESCRIPTION
## Brief description of the changes
This PR checks that the `onload` function is defined before calling it. This removes the `Uncaught TypeError: target.onload is not a function` console error while img preview.

## What browsers and operating systems have you tested these changes on?
Chrome 69.0.3497.100 on MacOS Sierra 10.13.6

## Have you written unit tests? If not, explain why.
No, because the modified code is likely already tested.
